### PR TITLE
step1 edits for FWLJMET

### DIFF
--- a/step1/makeStep1.C
+++ b/step1/makeStep1.C
@@ -13,12 +13,16 @@ void makeStep1(TString macroDir, TString inputFile, TString outputFile){
   gSystem->AddIncludePath(incl);
 
   step1 t(inputFile,outputFile);
-  t.saveHistograms();
+  if ( inputFile.Contains("Run2017") )
+    { t.Loop("ljmet", "ljmet"); }
 
-  vector<TString> shifts = { "ljmet", "ljmet_JECup", "ljmet_JECdown", "ljmet_JERup", "ljmet_JERdown" };
-  for (size_t i =0; i<shifts.size(); ++i) {
-    cout << endl << "Running shift " << shifts[i] << endl;
-    t.Loop(shifts[i], shifts[i]);
-}
+  else {
+    t.saveHistograms();
+    vector<TString> shifts = { "ljmet", "ljmet_JECup", "ljmet_JECdown", "ljmet_JERup", "ljmet_JERdown" };
+    for (size_t i =0; i<shifts.size(); ++i) {
+      cout << endl << "Running shift " << shifts[i] << endl;
+      t.Loop(shifts[i], shifts[i]);
+    }
+  }
 
 }

--- a/step1/makeStep1.C
+++ b/step1/makeStep1.C
@@ -17,8 +17,8 @@ void makeStep1(TString macroDir, TString inputFile, TString outputFile){
 
   vector<TString> shifts = { "ljmet", "ljmet_JECup", "ljmet_JECdown", "ljmet_JERup", "ljmet_JERdown" };
   for (size_t i =0; i<shifts.size(); ++i) {
-  cout << endl << "Running shift " << shifts[i] << endl;
-  t.Loop(shifts[i], shifts[i]);
+    cout << endl << "Running shift " << shifts[i] << endl;
+    t.Loop(shifts[i], shifts[i]);
 }
 
 }

--- a/step1/makeStep1.C
+++ b/step1/makeStep1.C
@@ -1,4 +1,6 @@
 #include "step1.cc"
+#include<vector>
+using namespace std;
 
 void makeStep1(TString macroDir, TString inputFile, TString outputFile){
 
@@ -11,5 +13,12 @@ void makeStep1(TString macroDir, TString inputFile, TString outputFile){
   gSystem->AddIncludePath(incl);
 
   step1 t(inputFile,outputFile);
-  t.Loop();
+  t.saveHistograms();
+
+  vector<TString> shifts = { "ljmet", "ljmet_JECup", "ljmet_JECdown", "ljmet_JERup", "ljmet_JERdown" };
+  for (size_t i =0; i<shifts.size(); ++i) {
+  cout << endl << "Running shift " << shifts[i] << endl;
+  t.Loop(shifts[i], shifts[i]);
+}
+
 }

--- a/step1/runCondorSlimmerJobs2017.py
+++ b/step1/runCondorSlimmerJobs2017.py
@@ -1,18 +1,18 @@
 import os,shutil,datetime,time,sys
 import getpass
+from glob import glob
 from ROOT import *
-execfile("/uscms_data/d3/jmanagan/EOSSafeUtils.py")
+execfile("./EOSSafeUtils.py")
 
 start_time = time.time()
 
-shift = sys.argv[1]
-
+finalStateYear = 'singleLep2017'
 #IO directories must be full paths
- 
-relbase   = '/uscms_data/d3/ssagir/fourtops/CMSSW_9_4_6_patch1/'
-inputDir  = '/eos/uscms/store/user/lpcljm/2018/LJMet94X_1lep_013019/'+shift+'/'
-outputDir = '/eos/uscms/store/user/jblee/LJMet94X_1lep_013019_step1/'+shift+'/'
-condorDir = '/uscms_data/d3/jblee/FourTops/CMSSW_9_4_6_patch1/src/TTTT/step1/'+shift+'/'
+relbase   = '/uscms_data/d3/wzhang/work/fwljmet_201905/CMSSW_10_2_10/'
+inputDir  = '/eos/uscms/store/user/lpcljm/FWLJMET102X_1lep2017_052219/'
+outputDir = '/eos/uscms/store/user/lpcljm/FWLJMET102X_1lep2017_4tops_06132019_step1/'
+condorDir = '/uscms_data/d3/wzhang/work/fwljmet_201905/CMSSW_10_2_10/src/LJMet-Slimmer-4tops/step1/logs/'+ finalStateYear +'/'
+
 
 runDir=os.getcwd()
 # Can change the file directory if needed
@@ -37,79 +37,23 @@ print 'Starting submission'
 count=0
 
 dirList = [
-# 	'WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 	'WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 	'WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 	'WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 	'WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8',
-
-# 	'DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8',
-# 	'QCD_HT1000to1500_TuneCP5_13TeV-madgraph-pythia8',
-# 	'QCD_HT1500to2000_TuneCP5_13TeV-madgraph-pythia8',
-# 	'QCD_HT2000toInf_TuneCP5_13TeV-madgraph-pythia8',
-# 	'QCD_HT300to500_TuneCP5_13TeV-madgraph-pythia8',
-# 	'QCD_HT500to700_TuneCP5_13TeV-madgraph-pythia8',
-# 	'QCD_HT700to1000_TuneCP5_13TeV-madgraph-pythia8',
-# 	
-# 	'ST_s-channel_4f_leptonDecays_TuneCP5_PSweights_13TeV-amcatnlo-pythia8',
-# 	'ST_t-channel_antitop_5f_TuneCP5_PSweights_13TeV-powheg-madspin-pythia8_vtd_vts_prod',
-# 	'ST_t-channel_antitop_5f_TuneCP5_PSweights_13TeV-powheg-pythia8',
-# 	'ST_t-channel_top_5f_TuneCP5_13TeV-powheg-pythia8',
-# 	'ST_t-channel_top_5f_TuneCP5_PSweights_13TeV-powheg-madspin-pythia8_vtd_vts_prod',
-# 	'ST_tW_antitop_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
-# 	'ST_tW_top_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
-# 
-# 	'TTWJetsToLNu_TuneCP5_PSweights_13TeV-amcatnloFXFX-madspin-pythia8',
-# 	'TTZToLL_M-1to10_TuneCP5_13TeV-amcatnlo-pythia8',
-# 	'TT_Mtt-1000toInf_TuneCP5_13TeV-powheg-pythia8',
-# 	'TT_Mtt-700to1000_TuneCP5_13TeV-powheg-pythia8',
-# 	'TTTT_TuneCP5_13TeV-amcatnlo-pythia8',
-
-
-# 'WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 'WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 'WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 'WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 'WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 'WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8',
-
-# 'DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8',
-# 'QCD_HT1000to1500_TuneCP5_13TeV-madgraph-pythia8',
-# 'QCD_HT1500to2000_TuneCP5_13TeV-madgraph-pythia8',
-# 'QCD_HT2000toInf_TuneCP5_13TeV-madgraph-pythia8',
-# 'QCD_HT200to300_TuneCP5_13TeV-madgraph-pythia8',
-# 'QCD_HT300to500_TuneCP5_13TeV-madgraph-pythia8',
-# 'QCD_HT500to700_TuneCP5_13TeV-madgraph-pythia8',
-# 'QCD_HT700to1000_TuneCP5_13TeV-madgraph-pythia8',
-
-# 'ST_s-channel_antitop_leptonDecays_13TeV-PSweights_powheg-pythia',
-# 'ST_s-channel_top_leptonDecays_13TeV-PSweights_powheg-pythia',
-# 'ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
-# 'ST_t-channel_top_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
-# 'ST_tW_antitop_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
-# 'ST_tW_top_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
-# 
-# 'ttWJets_TuneCP5_13TeV_madgraphMLM_pythia8',
-# 'ttZJets_TuneCP5_13TeV_madgraphMLM_pythia8',
-# 'TT_Mtt-1000toInf_TuneCP5_PSweights_13TeV-powheg-pythia8',
-# 'TT_Mtt-700to1000_TuneCP5_13TeV-powheg-pythia8',
-# 'TTTT_TuneCP5_PSweights_13TeV-amcatnlo-pythia8',
-
+'TT_Mtt-700to1000_TuneCP5_PSweights_13TeV-powheg-pythia8',
+#'TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8'
 ]
 
-# if shift == 'nominal':
-#     dirList.append('SingleElectron_31Mar18')
-#     dirList.append('SingleMuon_31Mar18')
 
 for sample in dirList:
-    os.system('eos root://cmseos.fnal.gov/ mkdir -p '+outDir+sample)
-    os.system('mkdir -p '+condorDir+sample)
-    relPath = sample
+  os.system('eos root://cmseos.fnal.gov/ mkdir -p '+outDir+sample)
+  os.system('mkdir -p '+condorDir+sample)
+  numpathlist = glob(inputDir+sample+'/'+finalStateYear+'/*/*')
+  tmpcount = 0
 
-    rootfiles = EOSlist_root_files(inputDir+sample)
-    tmpcount = 0
-    for i in range(0,len(rootfiles),20):
-        rawname = relPath
+  for numpath in numpathlist :
+      pathsuffix = numpath.split('/')[-3:]
+      pathsuffix = '/'.join(pathsuffix)
+      rootfiles = EOSlist_root_files(numpath)
+
+      for i in range(0,len(rootfiles),20):
         count += 1
         tmpcount += 1
         idlist = (rootfiles[i].split('.')[0]).split('_')[-1]+' '
@@ -119,8 +63,8 @@ for sample in dirList:
         idlist = idlist.strip()
         print idlist
 
-        dict={'RUNDIR':runDir, 'POST':runDirPost, 'RELPATH':relPath, 'CONDORDIR':condorDir, 'INPUTDIR':inDir, 'FILENAME':rawname, 'CMSSWBASE':relbase, 'OUTPUTDIR':outDir, 'LIST':idlist, 'ID':tmpcount}
-        jdfName=condorDir+'/%(RELPATH)s/%(FILENAME)s_%(ID)s.job'%dict
+        dict={'RUNDIR':runDir, 'POST':runDirPost, 'INPATHSUFFIX':pathsuffix, 'CONDORDIR':condorDir, 'INPUTDIR':inDir, 'FILENAME':sample, 'CMSSWBASE':relbase, 'OUTPUTDIR':outDir, 'LIST':idlist, 'ID':tmpcount}
+        jdfName=condorDir+'/%(FILENAME)s/%(FILENAME)s_%(ID)s.job'%dict
         print jdfName
         jdf=open(jdfName,'w')
         jdf.write(
@@ -134,65 +78,16 @@ Output = %(FILENAME)s_%(ID)s.out
 Error = %(FILENAME)s_%(ID)s.err
 Log = %(FILENAME)s_%(ID)s.log
 Notification = Never
-Arguments = "%(FILENAME)s %(FILENAME)s %(INPUTDIR)s/%(RELPATH)s %(OUTPUTDIR)s/%(RELPATH)s '%(LIST)s'"
+Arguments = "%(FILENAME)s %(FILENAME)s %(INPUTDIR)s/%(FILENAME)s/%(INPATHSUFFIX)s %(OUTPUTDIR)s/%(FILENAME)s '%(LIST)s'"
 Queue 1"""%dict)
         jdf.close()
-        os.chdir('%s/%s'%(condorDir,relPath))
+        os.chdir('%s/%s'%(condorDir,sample))
         os.system('condor_submit %(FILENAME)s_%(ID)s.job'%dict)
         os.system('sleep 0.5')                                
         os.chdir('%s'%(runDir))
         print count, "jobs submitted!!!"
-# os._exit(1)
-dirList = [ #inclusive tt sample only, split tt mass bins
-	'TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8',
-	'TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8',
-	'TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8',
-    ]
-TTOutList = ['Mtt0to700','Mtt700to1000','Mtt1000toInf']
+#        break
 
-for sample in dirList:
-    rootfiles = EOSlist_root_files(inputDir+sample)
-    relPath = sample
-    for outlabel in TTOutList:
-        os.system('eos root://cmseos.fnal.gov/ mkdir -p '+outDir+sample+'_'+outlabel)
-        os.system('mkdir -p '+condorDir+sample+'_'+outlabel)
-
-        tmpcount = 0
-        for i in range(0,len(rootfiles),20):            
-            rawname = relPath
-            count+=1
-            tmpcount += 1
-
-            idlist = (rootfiles[i].split('.')[0]).split('_')[-1]+' '
-            for j in range(i+1,i+20):
-                if j >= len(rootfiles): continue
-                idlist += (rootfiles[j].split('.')[0]).split('_')[-1]+' '
-            idlist = idlist.strip()
-            print idlist
-
-            dict={'RUNDIR':runDir, 'POST':runDirPost, 'RELPATH':relPath, 'LABEL':outlabel, 'CONDORDIR':condorDir, 'INPUTDIR':inDir, 'FILENAME':rawname, 'CMSSWBASE':relbase, 'OUTPUTDIR':outDir, 'LIST':idlist, 'ID':tmpcount}
-            jdfName=condorDir+'/%(RELPATH)s_%(LABEL)s/%(FILENAME)s_%(LABEL)s_%(ID)s.job'%dict
-            print jdfName
-            jdf=open(jdfName,'w')
-            jdf.write(
-                """use_x509userproxy = true
-universe = vanilla
-Executable = %(RUNDIR)s/makeStep1.sh
-Should_Transfer_Files = YES
-WhenToTransferOutput = ON_EXIT
-Transfer_Input_Files = %(RUNDIR)s/makeStep1.C, %(RUNDIR)s/%(POST)s/step1.cc, %(RUNDIR)s/%(POST)s/step1.h, %(RUNDIR)s/%(POST)s/step1_cc.d, %(RUNDIR)s/%(POST)s/step1_cc.so
-Output = %(FILENAME)s_%(LABEL)s_%(ID)s.out
-Error = %(FILENAME)s_%(LABEL)s_%(ID)s.err
-Log = %(FILENAME)s_%(LABEL)s_%(ID)s.log
-Notification = Never
-Arguments = "%(FILENAME)s %(FILENAME)s_%(LABEL)s %(INPUTDIR)s/%(RELPATH)s %(OUTPUTDIR)s/%(RELPATH)s_%(LABEL)s '%(LIST)s'"
-Queue 1"""%dict)
-            jdf.close()
-            os.chdir('%s/%s_%s'%(condorDir,relPath,outlabel))
-            os.system('condor_submit %(FILENAME)s_%(LABEL)s_%(ID)s.job'%dict)
-            os.system('sleep 0.5')                                
-            os.chdir('%s'%(runDir))
-            print count, "jobs submitted!!!"
 print("--- %s minutes ---" % (round(time.time() - start_time, 2)/60))
 
 

--- a/step1/runCondorSlimmerJobs2017.py
+++ b/step1/runCondorSlimmerJobs2017.py
@@ -6,12 +6,12 @@ execfile("./EOSSafeUtils.py")
 
 start_time = time.time()
 
-finalStateYear = 'singleLep2017'
+finalStateYear = 'singleLep2017' # CHANGE HERE
 #IO directories must be full paths
-relbase   = '/uscms_data/d3/wzhang/work/fwljmet_201905/CMSSW_10_2_10/'
-inputDir  = '/eos/uscms/store/user/lpcljm/FWLJMET102X_1lep2017_052219/'
-outputDir = '/eos/uscms/store/user/lpcljm/FWLJMET102X_1lep2017_4tops_06132019_step1/'
-condorDir = '/uscms_data/d3/wzhang/work/fwljmet_201905/CMSSW_10_2_10/src/LJMet-Slimmer-4tops/step1/logs/'+ finalStateYear +'/'
+relbase   = '/uscms_data/d3/wzhang/work/fwljmet_201905/CMSSW_10_2_10/' # CHANGE HERE
+inputDir  = '/eos/uscms/store/user/lpcljm/FWLJMET102X_1lep2017_052219/' # CHANGE HERE
+outputDir = '/eos/uscms/store/user/lpcljm/FWLJMET102X_1lep2017_4tops_06132019_step1/' # CHANGE HERE
+condorDir = '/uscms_data/d3/wzhang/work/fwljmet_201905/CMSSW_10_2_10/src/LJMet-Slimmer-4tops/step1/logs/'+ finalStateYear +'/' # CHANGE HERE
 
 
 runDir=os.getcwd()
@@ -47,7 +47,10 @@ for sample in dirList:
   os.system('mkdir -p '+condorDir+sample)
   tmpcount = 0
   runlist = EOSlistdir(inputDir+sample+'/'+finalStateYear+'/')
-
+  if len(runlist)>1: 
+    print "Please check this sample %s! Or put it into special MC list. "%(sample)
+    continue 
+    
   for run in runlist :
     numlist = EOSlistdir(inputDir+sample+'/'+finalStateYear+ '/'+ run +'/')
 
@@ -92,7 +95,62 @@ Queue 1"""%dict)
         print count, "jobs submitted!!!"
 #        break
 
+# special MC which have ext
+spdirList = [
+#'TTWW_TuneCP5_13TeV-madgraph-pythia8'
+]
 
+for sample in spdirList:
+  os.system('eos root://cmseos.fnal.gov/ mkdir -p '+outDir+sample)
+  os.system('mkdir -p '+condorDir+sample)
+  tmpcount = 0
+  runlist = EOSlistdir(inputDir+sample+'/'+finalStateYear+'/')
+
+  for run in runlist :
+    numlist = EOSlistdir(inputDir+sample+'/'+finalStateYear+ '/'+ run +'/')
+
+    for num in numlist :
+      numpath = inputDir+sample+'/'+finalStateYear+ '/'+ run +'/'+ num
+      pathsuffix = numpath.split('/')[-3:]
+      pathsuffix = '/'.join(pathsuffix)
+      rootfiles = EOSlist_root_files(numpath)
+
+      for i in range(0,len(rootfiles),20):
+        count += 1
+        tmpcount += 1
+        idlist = (rootfiles[i].split('.')[0]).split('_')[-1]+' '
+        for j in range(i+1,i+20):
+            if j >= len(rootfiles): continue
+            idlist += (rootfiles[j].split('.')[0]).split('_')[-1]+' '
+        idlist = idlist.strip()
+        print idlist
+
+        dict={'RUNDIR':runDir, 'POST':runDirPost, 'DATETIME':run, 'INPATHSUFFIX':pathsuffix, 'CONDORDIR':condorDir, 'INPUTDIR':inDir, 'FILENAME':sample, 'CMSSWBASE':relbase, 'OUTPUTDIR':outDir, 'LIST':idlist, 'ID':tmpcount}
+        jdfName=condorDir+'/%(FILENAME)s/%(FILENAME)s_%(ID)s.job'%dict
+        print jdfName
+        jdf=open(jdfName,'w')
+        jdf.write(
+            """use_x509userproxy = true
+universe = vanilla
+Executable = %(RUNDIR)s/makeStep1.sh
+Should_Transfer_Files = YES
+WhenToTransferOutput = ON_EXIT
+Transfer_Input_Files = %(RUNDIR)s/makeStep1.C, %(RUNDIR)s/%(POST)s/step1.cc, %(RUNDIR)s/%(POST)s/step1.h, %(RUNDIR)s/%(POST)s/step1_cc.d, %(RUNDIR)s/%(POST)s/step1_cc.so
+Output = %(FILENAME)s_%(ID)s.out
+Error = %(FILENAME)s_%(ID)s.err
+Log = %(FILENAME)s_%(ID)s.log
+Notification = Never
+Arguments = "%(FILENAME)s %(FILENAME)s_%(DATETIME)s %(INPUTDIR)s/%(FILENAME)s/%(INPATHSUFFIX)s %(OUTPUTDIR)s/%(FILENAME)s '%(LIST)s'"
+Queue 1"""%dict)
+        jdf.close()
+        os.chdir('%s/%s'%(condorDir,sample))
+        os.system('condor_submit %(FILENAME)s_%(ID)s.job'%dict)
+        os.system('sleep 0.5')                                
+        os.chdir('%s'%(runDir))
+        print count, "jobs submitted!!!"
+#        break
+
+# data
 datadirList = [
 'SingleElectron'
 ]

--- a/step1/step1.cc
+++ b/step1/step1.cc
@@ -20,7 +20,8 @@ using namespace std;
 // Define functions
 // ----------------------------------------------------------------------------
 
-bool comparepair( const std::pair<double,int> a, const std::pair<double,int> b) { return a.first > b.first; }
+bool comparepair( const std::pair<double,int> a, const std::pair<double,int> b) {
+ return a.first > b.first; }
 
 TRandom3 Rand;
 
@@ -56,16 +57,33 @@ bool step1::applySF(bool& isTagged, float tag_SF, float tag_eff){
   return newTag;
 }
 
+// -------------------------------------
+// Function- SAVE Histograms from ljmet
+//--------------------------------------
+void step1::saveHistograms() 
+{ 
+TH1D* numhist = (TH1D*)inputFile->Get("mcweightanalyzer/NumTrueHist");
+TH1D* wgthist = (TH1D*)inputFile->Get("mcweightanalyzer/weightHist");
+outputFile->cd();
+numhist->Write();
+wgthist->Write();
+
+}
+
+
 // ----------------------------------------------------------------------------
 // MAIN EVENT LOOP
 // ----------------------------------------------------------------------------
 
-void step1::Loop() 
+void step1::Loop(TString inTreeName, TString outTreeName ) 
 {
   
   // ----------------------------------------------------------------------------
   // Turn on input tree branches
   // ----------------------------------------------------------------------------
+  inputTree=(TTree*)inputFile->Get(inTreeName+"/"+inTreeName);
+  if(inputTree->GetEntries()==0) std::cout<<"WARNING! Found 0 events in the tree!!!!"<<std::endl;;
+  Init(inputTree);
 
    if (inputTree == 0) return;
    
@@ -75,64 +93,64 @@ void step1::Loop()
    inputTree->SetBranchStatus("event_CommonCalc",1);
    inputTree->SetBranchStatus("run_CommonCalc",1);
    inputTree->SetBranchStatus("lumi_CommonCalc",1);
-   inputTree->SetBranchStatus("nPV_singleLepCalc",1);
-   inputTree->SetBranchStatus("nTrueInteractions_singleLepCalc",1);
-   inputTree->SetBranchStatus("MCWeight_singleLepCalc",1);
-   inputTree->SetBranchStatus("LHEweightids_singleLepCalc",1);
-   inputTree->SetBranchStatus("LHEweights_singleLepCalc",1);
-   inputTree->SetBranchStatus("HTfromHEPUEP_singleLepCalc",1);
+   inputTree->SetBranchStatus("nPV_MultiLepCalc",1);
+   inputTree->SetBranchStatus("nTrueInteractions_MultiLepCalc",1);
+   inputTree->SetBranchStatus("MCWeight_MultiLepCalc",1);
+   inputTree->SetBranchStatus("LHEweightids_MultiLepCalc",1);
+   inputTree->SetBranchStatus("LHEweights_MultiLepCalc",1);
+   inputTree->SetBranchStatus("HTfromHEPUEP_MultiLepCalc",1);
    
    //triggers
-   inputTree->SetBranchStatus("vsSelMCTriggersEl_singleLepCalc",1);
-   inputTree->SetBranchStatus("viSelMCTriggersEl_singleLepCalc",1);
-   inputTree->SetBranchStatus("vsSelMCTriggersMu_singleLepCalc",1);
-   inputTree->SetBranchStatus("viSelMCTriggersMu_singleLepCalc",1);
-   inputTree->SetBranchStatus("vsSelTriggersEl_singleLepCalc",1);
-   inputTree->SetBranchStatus("viSelTriggersEl_singleLepCalc",1);
-   inputTree->SetBranchStatus("vsSelTriggersMu_singleLepCalc",1);
-   inputTree->SetBranchStatus("viSelTriggersMu_singleLepCalc",1);
+   inputTree->SetBranchStatus("vsSelMCTriggersEl_MultiLepCalc",1);
+   inputTree->SetBranchStatus("viSelMCTriggersEl_MultiLepCalc",1);
+   inputTree->SetBranchStatus("vsSelMCTriggersMu_MultiLepCalc",1);
+   inputTree->SetBranchStatus("viSelMCTriggersMu_MultiLepCalc",1);
+   inputTree->SetBranchStatus("vsSelTriggersEl_MultiLepCalc",1);
+   inputTree->SetBranchStatus("viSelTriggersEl_MultiLepCalc",1);
+   inputTree->SetBranchStatus("vsSelTriggersMu_MultiLepCalc",1);
+   inputTree->SetBranchStatus("viSelTriggersMu_MultiLepCalc",1);
    
    //electrons **** ADD MORE/NEW ID BRANCHES *****
-   inputTree->SetBranchStatus("elPt_singleLepCalc",1);
-   inputTree->SetBranchStatus("elEta_singleLepCalc",1);
-   inputTree->SetBranchStatus("elPhi_singleLepCalc",1);
-   inputTree->SetBranchStatus("elEnergy_singleLepCalc",1);
-   inputTree->SetBranchStatus("elMVAValue_singleLepCalc",1);
-   inputTree->SetBranchStatus("elMiniIso_singleLepCalc",1);
-   inputTree->SetBranchStatus("elIsTightBarrel_singleLepCalc",1);
-   inputTree->SetBranchStatus("elIsMediumBarrel_singleLepCalc",1);
-   inputTree->SetBranchStatus("elIsLooseBarrel_singleLepCalc",1);
-   inputTree->SetBranchStatus("elIsVetoBarrel_singleLepCalc",1);
-   inputTree->SetBranchStatus("elIsMediumEndCap_singleLepCalc",1);
-   inputTree->SetBranchStatus("elIsLooseEndCap_singleLepCalc",1);
-   inputTree->SetBranchStatus("elIsVetoEndCap_singleLepCalc",1);
-   inputTree->SetBranchStatus("elMother_id_singleLepCalc",1);
-   inputTree->SetBranchStatus("elMother_pt_singleLepCalc",1);
-   inputTree->SetBranchStatus("elMother_eta_singleLepCalc",1);
-   inputTree->SetBranchStatus("elMother_phi_singleLepCalc",1);
-   inputTree->SetBranchStatus("elMother_energy_singleLepCalc",1);
-   inputTree->SetBranchStatus("elNumberOfMothers_singleLepCalc",1);   
+   inputTree->SetBranchStatus("elPt_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elEta_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elPhi_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elEnergy_MultiLepCalc",1);
+//   inputTree->SetBranchStatus("elMVAValue_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elMiniIso_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elIsTightBarrel_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elIsMediumBarrel_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elIsLooseBarrel_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elIsVetoBarrel_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elIsMediumEndCap_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elIsLooseEndCap_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elIsVetoEndCap_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elMother_id_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elMother_pt_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elMother_eta_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elMother_phi_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elMother_energy_MultiLepCalc",1);
+   inputTree->SetBranchStatus("elNumberOfMothers_MultiLepCalc",1);   
    
    //muons  **** ADD MORE/NEW ID BRANCHES *****
-   inputTree->SetBranchStatus("muPt_singleLepCalc",1);
-   inputTree->SetBranchStatus("muEta_singleLepCalc",1);
-   inputTree->SetBranchStatus("muPhi_singleLepCalc",1);
-   inputTree->SetBranchStatus("muEnergy_singleLepCalc",1);
-   inputTree->SetBranchStatus("muMiniIso_singleLepCalc",1);
-   inputTree->SetBranchStatus("muIsTight_singleLepCalc",1);
-   inputTree->SetBranchStatus("muIsMedium_singleLepCalc",1);
-   inputTree->SetBranchStatus("muIsMediumPrompt_singleLepCalc",1);
-   inputTree->SetBranchStatus("muIsLoose_singleLepCalc",1);
-   inputTree->SetBranchStatus("muMother_id_singleLepCalc",1);   
-   inputTree->SetBranchStatus("muMother_pt_singleLepCalc",1);   
-   inputTree->SetBranchStatus("muMother_eta_singleLepCalc",1);   
-   inputTree->SetBranchStatus("muMother_phi_singleLepCalc",1);   
-   inputTree->SetBranchStatus("muMother_energy_singleLepCalc",1);   
-   inputTree->SetBranchStatus("muNumberOfMothers_singleLepCalc",1);   
+   inputTree->SetBranchStatus("muPt_MultiLepCalc",1);
+   inputTree->SetBranchStatus("muEta_MultiLepCalc",1);
+   inputTree->SetBranchStatus("muPhi_MultiLepCalc",1);
+   inputTree->SetBranchStatus("muEnergy_MultiLepCalc",1);
+   inputTree->SetBranchStatus("muMiniIso_MultiLepCalc",1);
+   inputTree->SetBranchStatus("muIsTight_MultiLepCalc",1);
+   inputTree->SetBranchStatus("muIsMedium_MultiLepCalc",1);
+   inputTree->SetBranchStatus("muIsMediumPrompt_MultiLepCalc",1);
+   inputTree->SetBranchStatus("muIsLoose_MultiLepCalc",1);
+   inputTree->SetBranchStatus("muMother_id_MultiLepCalc",1);   
+   inputTree->SetBranchStatus("muMother_pt_MultiLepCalc",1);   
+   inputTree->SetBranchStatus("muMother_eta_MultiLepCalc",1);   
+   inputTree->SetBranchStatus("muMother_phi_MultiLepCalc",1);   
+   inputTree->SetBranchStatus("muMother_energy_MultiLepCalc",1);   
+   inputTree->SetBranchStatus("muNumberOfMothers_MultiLepCalc",1);   
    
    //missing et
-   inputTree->SetBranchStatus("corr_met_singleLepCalc",1);
-   inputTree->SetBranchStatus("corr_met_phi_singleLepCalc",1);
+   inputTree->SetBranchStatus("corr_met_MultiLepCalc",1);
+   inputTree->SetBranchStatus("corr_met_phi_MultiLepCalc",1);
 
    //boosted truth
    inputTree->SetBranchStatus("HadronicVHtPt_JetSubCalc",1);
@@ -154,19 +172,19 @@ void step1::Loop()
    inputTree->SetBranchStatus("HadronicVHtD2E_JetSubCalc",1);
 
    //genParticles
-   inputTree->SetBranchStatus("genPt_singleLepCalc",1);
-   inputTree->SetBranchStatus("genEta_singleLepCalc",1);
-   inputTree->SetBranchStatus("genPhi_singleLepCalc",1);
-   inputTree->SetBranchStatus("genEnergy_singleLepCalc",1);
-   inputTree->SetBranchStatus("genStatus_singleLepCalc",1);
-   inputTree->SetBranchStatus("genID_singleLepCalc",1);
-   inputTree->SetBranchStatus("genIndex_singleLepCalc",1);
-   inputTree->SetBranchStatus("genMotherID_singleLepCalc",1);
-   inputTree->SetBranchStatus("genMotherIndex_singleLepCalc",1);
-   inputTree->SetBranchStatus("genJetPt_singleLepCalc",1);
-   inputTree->SetBranchStatus("genJetEta_singleLepCalc",1);
-   inputTree->SetBranchStatus("genJetPhi_singleLepCalc",1);
-   inputTree->SetBranchStatus("genJetEnergy_singleLepCalc",1);
+   inputTree->SetBranchStatus("genPt_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genEta_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genPhi_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genEnergy_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genStatus_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genID_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genIndex_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genMotherID_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genMotherIndex_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genJetPt_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genJetEta_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genJetPhi_MultiLepCalc",1);
+   inputTree->SetBranchStatus("genJetEnergy_MultiLepCalc",1);
    inputTree->SetBranchStatus("genTtbarIdCategory_TTbarMassCalc",1);
 
    //JetSubCalc
@@ -252,7 +270,7 @@ void step1::Loop()
    
    // OUTPUT FILE
    outputFile->cd();
-   TTree *outputTree = new TTree("ljmet","ljmet");
+   TTree *outputTree = new TTree(outTreeName, outTreeName);
 
 
 
@@ -260,13 +278,13 @@ void step1::Loop()
    outputTree->Branch("event_CommonCalc",&event_CommonCalc,"event_CommonCalc/L");
    outputTree->Branch("run_CommonCalc",&run_CommonCalc,"run_CommonCalc/I");
    outputTree->Branch("lumi_CommonCalc",&lumi_CommonCalc,"lumi_CommonCalc/I");
-   outputTree->Branch("nPV_singleLepCalc",&nPV_singleLepCalc,"nPV_singleLepCalc/I");
-   outputTree->Branch("nTrueInteractions_singleLepCalc",&nTrueInteractions_singleLepCalc,"nTrueInteractions_singleLepCalc/I");
+   outputTree->Branch("nPV_MultiLepCalc",&nPV_MultiLepCalc,"nPV_MultiLepCalc/I");
+   outputTree->Branch("nTrueInteractions_MultiLepCalc",&nTrueInteractions_MultiLepCalc,"nTrueInteractions_MultiLepCalc/I");
    outputTree->Branch("isElectron",&isElectron,"isElectron/I");
    outputTree->Branch("isMuon",&isMuon,"isMuon/I");
    outputTree->Branch("MCPastTrigger",&MCPastTrigger,"MCPastTrigger/I");
    outputTree->Branch("DataPastTrigger",&DataPastTrigger,"DataPastTrigger/I");
-   outputTree->Branch("MCWeight_singleLepCalc",&MCWeight_singleLepCalc,"MCWeight_singleLepCalc/D");
+   outputTree->Branch("MCWeight_MultiLepCalc",&MCWeight_MultiLepCalc,"MCWeight_MultiLepCalc/D");
    outputTree->Branch("renormWeights",&renormWeights);
    outputTree->Branch("pdfWeights",&pdfWeights);
    outputTree->Branch("pileupWeight",&pileupWeight,"pileupWeight/F");
@@ -277,14 +295,14 @@ void step1::Loop()
    outputTree->Branch("HTSF_PolDn",&HTSF_PolDn,"HTSF_PolDn/F");
    outputTree->Branch("ttbarMass_TTbarMassCalc",&ttbarMass_TTbarMassCalc,"ttbarMass_TTbarMassCalc/D");
    outputTree->Branch("isTT_TTbarMassCalc",&isTT_TTbarMassCalc,"isTT_TTbarMassCalc/I");
-   outputTree->Branch("corr_met_singleLepCalc",&corr_met_singleLepCalc,"corr_met_singleLepCalc/D");
-   outputTree->Branch("corr_met_phi_singleLepCalc",&corr_met_phi_singleLepCalc,"corr_met_phi_singleLepCalc/D");
-   outputTree->Branch("leptonPt_singleLepCalc",&leptonPt_singleLepCalc,"leptonPt_singleLepCalc/F");
-   outputTree->Branch("leptonEta_singleLepCalc",&leptonEta_singleLepCalc,"leptonEta_singleLepCalc/F");
-   outputTree->Branch("leptonPhi_singleLepCalc",&leptonPhi_singleLepCalc,"leptonPhi_singleLepCalc/F");
-   outputTree->Branch("leptonEnergy_singleLepCalc",&leptonEnergy_singleLepCalc,"leptonEnergy_singleLepCalc/F");
-   outputTree->Branch("leptonMVAValue_singleLepCalc",&leptonMVAValue_singleLepCalc,"leptonMVAValue_singleLepCalc/F");
-   outputTree->Branch("leptonMiniIso_singleLepCalc",&leptonMiniIso_singleLepCalc,"leptonMiniIso_singleLepCalc/F");
+   outputTree->Branch("corr_met_MultiLepCalc",&corr_met_MultiLepCalc,"corr_met_MultiLepCalc/D");
+   outputTree->Branch("corr_met_phi_MultiLepCalc",&corr_met_phi_MultiLepCalc,"corr_met_phi_MultiLepCalc/D");
+   outputTree->Branch("leptonPt_MultiLepCalc",&leptonPt_MultiLepCalc,"leptonPt_MultiLepCalc/F");
+   outputTree->Branch("leptonEta_MultiLepCalc",&leptonEta_MultiLepCalc,"leptonEta_MultiLepCalc/F");
+   outputTree->Branch("leptonPhi_MultiLepCalc",&leptonPhi_MultiLepCalc,"leptonPhi_MultiLepCalc/F");
+   outputTree->Branch("leptonEnergy_MultiLepCalc",&leptonEnergy_MultiLepCalc,"leptonEnergy_MultiLepCalc/F");
+   outputTree->Branch("leptonMVAValue_MultiLepCalc",&leptonMVAValue_MultiLepCalc,"leptonMVAValue_MultiLepCalc/F");
+   outputTree->Branch("leptonMiniIso_MultiLepCalc",&leptonMiniIso_MultiLepCalc,"leptonMiniIso_MultiLepCalc/F");
    outputTree->Branch("theJetPt_JetSubCalc_PtOrdered",&theJetPt_JetSubCalc_PtOrdered);
    outputTree->Branch("theJetEta_JetSubCalc_PtOrdered",&theJetEta_JetSubCalc_PtOrdered);
    outputTree->Branch("theJetPhi_JetSubCalc_PtOrdered",&theJetPhi_JetSubCalc_PtOrdered);
@@ -317,34 +335,34 @@ void step1::Loop()
    outputTree->Branch("MT_lepMet",&MT_lepMet,"MT_lepMet/F");
    outputTree->Branch("deltaR_lepJets",&deltaR_lepJets);
    outputTree->Branch("deltaR_lepBJets",&deltaR_lepBJets);
-   outputTree->Branch("muIsLoose_singleLepCalc",&muIsLoose_singleLepCalc);
-   outputTree->Branch("muIsMedium_singleLepCalc",&muIsMedium_singleLepCalc);
-   outputTree->Branch("muIsMediumPrompt_singleLepCalc",&muIsMediumPrompt_singleLepCalc);
-   outputTree->Branch("muIsTight_singleLepCalc",&muIsTight_singleLepCalc);
+   outputTree->Branch("muIsLoose_MultiLepCalc",&muIsLoose_MultiLepCalc);
+   outputTree->Branch("muIsMedium_MultiLepCalc",&muIsMedium_MultiLepCalc);
+   outputTree->Branch("muIsMediumPrompt_MultiLepCalc",&muIsMediumPrompt_MultiLepCalc);
+   outputTree->Branch("muIsTight_MultiLepCalc",&muIsTight_MultiLepCalc);
 
-   outputTree->Branch("muPt_singleLepCalc",&muPt_singleLepCalc);
-   outputTree->Branch("muMother_id_singleLepCalc",&muMother_id_singleLepCalc);
-   outputTree->Branch("muMother_pt_singleLepCalc",&muMother_pt_singleLepCalc);
-   outputTree->Branch("muMother_eta_singleLepCalc",&muMother_eta_singleLepCalc);
-   outputTree->Branch("muMother_phi_singleLepCalc",&muMother_phi_singleLepCalc);
-   outputTree->Branch("muMother_energy_singleLepCalc",&muMother_energy_singleLepCalc);         
-   outputTree->Branch("muNumberOfMothers_singleLepCalc",&muNumberOfMothers_singleLepCalc);            
+   outputTree->Branch("muPt_MultiLepCalc",&muPt_MultiLepCalc);
+   outputTree->Branch("muMother_id_MultiLepCalc",&muMother_id_MultiLepCalc);
+   outputTree->Branch("muMother_pt_MultiLepCalc",&muMother_pt_MultiLepCalc);
+   outputTree->Branch("muMother_eta_MultiLepCalc",&muMother_eta_MultiLepCalc);
+   outputTree->Branch("muMother_phi_MultiLepCalc",&muMother_phi_MultiLepCalc);
+   outputTree->Branch("muMother_energy_MultiLepCalc",&muMother_energy_MultiLepCalc);         
+   outputTree->Branch("muNumberOfMothers_MultiLepCalc",&muNumberOfMothers_MultiLepCalc);            
 
-   outputTree->Branch("elPt_singleLepCalc",&elPt_singleLepCalc);
-   outputTree->Branch("elIsTightBarrel_singleLepCalc",&elIsTightBarrel_singleLepCalc,"elIsTightBarrel_singleLepCalc/F");
-   outputTree->Branch("elIsMediumBarrel_singleLepCalc",&elIsMediumBarrel_singleLepCalc,"elIsMediumBarrel_singleLepCalc/F");
-   outputTree->Branch("elIsLooseBarrel_singleLepCalc",&elIsLooseBarrel_singleLepCalc,"elIsLooseBarrel_singleLepCalc/F");
-   outputTree->Branch("elIsVetoBarrel_singleLepCalc",&elIsVetoBarrel_singleLepCalc,"elIsVetoBarrel_singleLepCalc/F");
-   outputTree->Branch("elIsTightEndCap_singleLepCalc",&elIsTightEndCap_singleLepCalc,"elIsTightEndCap_singleLepCalc/F");
-   outputTree->Branch("elIsMediumEndCap_singleLepCalc",&elIsMediumEndCap_singleLepCalc,"elIsMediumEndCap_singleLepCalc/F");
-   outputTree->Branch("elIsLooseEndCap_singleLepCalc",&elIsLooseEndCap_singleLepCalc,"elIsLooseEndCap_singleLepCalc/F");
-   outputTree->Branch("elIsVetoEndCap_singleLepCalc",&elIsVetoEndCap_singleLepCalc,"elIsVetoEndCap_singleLepCalc/F");
-   outputTree->Branch("elMother_id_singleLepCalc",&elMother_id_singleLepCalc);
-   outputTree->Branch("elMother_pt_singleLepCalc",&elMother_pt_singleLepCalc);
-   outputTree->Branch("elMother_eta_singleLepCalc",&elMother_eta_singleLepCalc);
-   outputTree->Branch("elMother_phi_singleLepCalc",&elMother_phi_singleLepCalc);
-   outputTree->Branch("elMother_energy_singleLepCalc",&elMother_energy_singleLepCalc);         
-   outputTree->Branch("elNumberOfMothers_singleLepCalc",&elNumberOfMothers_singleLepCalc);            
+   outputTree->Branch("elPt_MultiLepCalc",&elPt_MultiLepCalc);
+   outputTree->Branch("elIsTightBarrel_MultiLepCalc",&elIsTightBarrel_MultiLepCalc,"elIsTightBarrel_MultiLepCalc/F");
+   outputTree->Branch("elIsMediumBarrel_MultiLepCalc",&elIsMediumBarrel_MultiLepCalc,"elIsMediumBarrel_MultiLepCalc/F");
+   outputTree->Branch("elIsLooseBarrel_MultiLepCalc",&elIsLooseBarrel_MultiLepCalc,"elIsLooseBarrel_MultiLepCalc/F");
+   outputTree->Branch("elIsVetoBarrel_MultiLepCalc",&elIsVetoBarrel_MultiLepCalc,"elIsVetoBarrel_MultiLepCalc/F");
+   outputTree->Branch("elIsTightEndCap_MultiLepCalc",&elIsTightEndCap_MultiLepCalc,"elIsTightEndCap_MultiLepCalc/F");
+   outputTree->Branch("elIsMediumEndCap_MultiLepCalc",&elIsMediumEndCap_MultiLepCalc,"elIsMediumEndCap_MultiLepCalc/F");
+   outputTree->Branch("elIsLooseEndCap_MultiLepCalc",&elIsLooseEndCap_MultiLepCalc,"elIsLooseEndCap_MultiLepCalc/F");
+   outputTree->Branch("elIsVetoEndCap_MultiLepCalc",&elIsVetoEndCap_MultiLepCalc,"elIsVetoEndCap_MultiLepCalc/F");
+   outputTree->Branch("elMother_id_MultiLepCalc",&elMother_id_MultiLepCalc);
+   outputTree->Branch("elMother_pt_MultiLepCalc",&elMother_pt_MultiLepCalc);
+   outputTree->Branch("elMother_eta_MultiLepCalc",&elMother_eta_MultiLepCalc);
+   outputTree->Branch("elMother_phi_MultiLepCalc",&elMother_phi_MultiLepCalc);
+   outputTree->Branch("elMother_energy_MultiLepCalc",&elMother_energy_MultiLepCalc);         
+   outputTree->Branch("elNumberOfMothers_MultiLepCalc",&elNumberOfMothers_MultiLepCalc);            
 
    outputTree->Branch("EGammaGsfSF",&EGammaGsfSF,"EGammaGsfSF/F");
    outputTree->Branch("lepIdSF",&lepIdSF,"lepIdSF/F");
@@ -386,19 +404,19 @@ void step1::Loop()
    outputTree->Branch("minDR_lepAK8",&minDR_lepAK8,"minDR_lepAK8/F");
    outputTree->Branch("deltaR_lepAK8s",&deltaR_lepAK8s);
 
-   outputTree->Branch("genPt_singleLepCalc",&genPt_singleLepCalc);
-   outputTree->Branch("genEta_singleLepCalc",&genEta_singleLepCalc);
-   outputTree->Branch("genPhi_singleLepCalc",&genPhi_singleLepCalc);
-   outputTree->Branch("genEnergy_singleLepCalc",&genEnergy_singleLepCalc);
-   outputTree->Branch("genStatus_singleLepCalc",&genStatus_singleLepCalc);
-   outputTree->Branch("genID_singleLepCalc",&genID_singleLepCalc);
-   outputTree->Branch("genJetPt_singleLepCalc",&genJetPt_singleLepCalc);                  
-   outputTree->Branch("genJetEta_singleLepCalc",&genJetEta_singleLepCalc);                     
-   outputTree->Branch("genJetPhi_singleLepCalc",&genJetPhi_singleLepCalc);                  
-   outputTree->Branch("genJetEnergy_singleLepCalc",&genJetEnergy_singleLepCalc);                  
-   outputTree->Branch("genIndex_singleLepCalc",&genIndex_singleLepCalc);
-   outputTree->Branch("genMotherID_singleLepCalc",&genMotherID_singleLepCalc);
-   outputTree->Branch("genMotherIndex_singleLepCalc",&genMotherIndex_singleLepCalc);
+   outputTree->Branch("genPt_MultiLepCalc",&genPt_MultiLepCalc);
+   outputTree->Branch("genEta_MultiLepCalc",&genEta_MultiLepCalc);
+   outputTree->Branch("genPhi_MultiLepCalc",&genPhi_MultiLepCalc);
+   outputTree->Branch("genEnergy_MultiLepCalc",&genEnergy_MultiLepCalc);
+   outputTree->Branch("genStatus_MultiLepCalc",&genStatus_MultiLepCalc);
+   outputTree->Branch("genID_MultiLepCalc",&genID_MultiLepCalc);
+   outputTree->Branch("genJetPt_MultiLepCalc",&genJetPt_MultiLepCalc);                  
+   outputTree->Branch("genJetEta_MultiLepCalc",&genJetEta_MultiLepCalc);                     
+   outputTree->Branch("genJetPhi_MultiLepCalc",&genJetPhi_MultiLepCalc);                  
+   outputTree->Branch("genJetEnergy_MultiLepCalc",&genJetEnergy_MultiLepCalc);                  
+   outputTree->Branch("genIndex_MultiLepCalc",&genIndex_MultiLepCalc);
+   outputTree->Branch("genMotherID_MultiLepCalc",&genMotherID_MultiLepCalc);
+   outputTree->Branch("genMotherIndex_MultiLepCalc",&genMotherIndex_MultiLepCalc);
    outputTree->Branch("genTtbarIdCategory_TTbarMassCalc",&genTtbarIdCategory_TTbarMassCalc);
 
 
@@ -763,11 +781,11 @@ void step1::Loop()
       // **** Choose an electron and muon ID for "tight" and find events with only 1 tight el or mu by that definition
       isElectron = 0;
       isMuon = 0;
-      if(elPt_singleLepCalc->size()==0 && muPt_singleLepCalc->size()==0){std::cout << "got no leptons, something wrong" << std::endl; continue;}
-      if(elPt_singleLepCalc->size()>0 && muPt_singleLepCalc->size()>0) std::cout << "got el and mu, something wrong" << std::endl;
-      if(elPt_singleLepCalc->size()>1 || muPt_singleLepCalc->size()>1) std::cout << "got more than one el or mu, something wrong" << std::endl;
-      if(elPt_singleLepCalc->size()>0 && muPt_singleLepCalc->size()==0) {isElectron = 1; isMuon = 0;}
-      if(elPt_singleLepCalc->size()==0 && muPt_singleLepCalc->size()>0) {isElectron = 0; isMuon = 1;}
+      if(elPt_MultiLepCalc->size()==0 && muPt_MultiLepCalc->size()==0){std::cout << "got no leptons, something wrong" << std::endl; continue;}
+      if(elPt_MultiLepCalc->size()>0 && muPt_MultiLepCalc->size()>0) std::cout << "got el and mu, something wrong" << std::endl;
+      if(elPt_MultiLepCalc->size()>1 || muPt_MultiLepCalc->size()>1) std::cout << "got more than one el or mu, something wrong" << std::endl;
+      if(elPt_MultiLepCalc->size()>0 && muPt_MultiLepCalc->size()==0) {isElectron = 1; isMuon = 0;}
+      if(elPt_MultiLepCalc->size()==0 && muPt_MultiLepCalc->size()>0) {isElectron = 0; isMuon = 1;}
       if(isElectron==0 && isMuon==0){std::cout << "got no leptons, something wrong" << std::endl; continue;}
 
       if(isSM && isElectron == 1) continue;
@@ -775,8 +793,8 @@ void step1::Loop()
 
       double leppt = 0;
       double lepeta = 0;
-      if(isElectron){leppt = elPt_singleLepCalc->at(0); lepeta = elEta_singleLepCalc->at(0);}
-      if(isMuon){leppt = muPt_singleLepCalc->at(0); lepeta = muEta_singleLepCalc->at(0);}
+      if(isElectron){leppt = elPt_MultiLepCalc->at(0); lepeta = elEta_MultiLepCalc->at(0);}
+      if(isMuon){leppt = muPt_MultiLepCalc->at(0); lepeta = muEta_MultiLepCalc->at(0);}
 
       // ----------------------------------------------------------------------------
       // Pileup weight calculation
@@ -787,15 +805,15 @@ void step1::Loop()
       pileupWeightDown = 1.0;
 	
       if(isMC){
-	if(nTrueInteractions_singleLepCalc > 79) nTrueInteractions_singleLepCalc = 79;
-	if(nTrueInteractions_singleLepCalc < 0) nTrueInteractions_singleLepCalc = 0;
+	if(nTrueInteractions_MultiLepCalc > 79) nTrueInteractions_MultiLepCalc = 79;
+	if(nTrueInteractions_MultiLepCalc < 0) nTrueInteractions_MultiLepCalc = 0;
 	if(pileupIndex < 1 || pileupIndex > 32){
 	  std::cout << "I don't know this pileup sample, using TTToSemiLeptonic's" << std::endl;
 	  pileupIndex = 14;
 	}
-	pileupWeight = pileupweight[pileupIndex-1][nTrueInteractions_singleLepCalc];
-	pileupWeightUp = pileupweightUp[pileupIndex-1][nTrueInteractions_singleLepCalc];
-	pileupWeightDown = pileupweightDn[pileupIndex-1][nTrueInteractions_singleLepCalc];
+	pileupWeight = pileupweight[pileupIndex-1][nTrueInteractions_MultiLepCalc];
+	pileupWeightUp = pileupweightUp[pileupIndex-1][nTrueInteractions_MultiLepCalc];
+	pileupWeightDown = pileupweightDn[pileupIndex-1][nTrueInteractions_MultiLepCalc];
       }
 
       // ----------------------------------------------------------------------------
@@ -816,13 +834,13 @@ void step1::Loop()
 	  std::string string_d = "Ele15_IsoVVVL_PFHT600";
 	  std::string string_ORa = "Ele35_WPTight_Gsf";
 	  std::string string_ORb = "Ele38_WPTight_Gsf";
-	  for(unsigned int itrig=0; itrig < vsSelMCTriggersEl_singleLepCalc->size(); itrig++){
-	    if(vsSelMCTriggersEl_singleLepCalc->at(itrig).find(string_a) != std::string::npos && viSelMCTriggersEl_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-	    if(vsSelMCTriggersEl_singleLepCalc->at(itrig).find(string_b) != std::string::npos && viSelMCTriggersEl_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-            if(vsSelMCTriggersEl_singleLepCalc->at(itrig).find(string_c) != std::string::npos && viSelMCTriggersEl_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-            if(vsSelMCTriggersEl_singleLepCalc->at(itrig).find(string_d) != std::string::npos && viSelMCTriggersEl_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-	    if(vsSelMCTriggersEl_singleLepCalc->at(itrig).find(string_ORa) != std::string::npos && viSelMCTriggersEl_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-	    if(vsSelMCTriggersEl_singleLepCalc->at(itrig).find(string_ORb) != std::string::npos && viSelMCTriggersEl_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+	  for(unsigned int itrig=0; itrig < vsSelMCTriggersEl_MultiLepCalc->size(); itrig++){
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(string_a) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(string_b) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+            if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(string_c) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+            if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(string_d) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(string_ORa) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(string_ORb) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
 	  }
 	  // Gsf Tracking scale factor: http://fcouderc.web.cern.ch/fcouderc/EGamma/scaleFactors/Moriond17/approval/RECO/passingRECO/egammaEffi.txt_egammaPlots.pdf
 	  if (leppt < 45) {
@@ -943,14 +961,14 @@ void step1::Loop()
 	  std::string string_e = "Mu15_IsoVVVL_PFHT600";
 	  std::string string_ORb = "Mu50";
 	  std::string string_ORc = "TkMu50";
-	  for(unsigned int itrig=0; itrig < vsSelMCTriggersMu_singleLepCalc->size(); itrig++){
-	    if(vsSelMCTriggersMu_singleLepCalc->at(itrig).find(string_a) != std::string::npos && viSelMCTriggersMu_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-	    if(vsSelMCTriggersMu_singleLepCalc->at(itrig).find(string_b) != std::string::npos && viSelMCTriggersMu_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-            if(vsSelMCTriggersMu_singleLepCalc->at(itrig).find(string_c) != std::string::npos && viSelMCTriggersMu_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-            if(vsSelMCTriggersMu_singleLepCalc->at(itrig).find(string_d) != std::string::npos && viSelMCTriggersMu_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-            if(vsSelMCTriggersMu_singleLepCalc->at(itrig).find(string_e) != std::string::npos && viSelMCTriggersMu_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-	    if(vsSelMCTriggersMu_singleLepCalc->at(itrig).find(string_ORb) != std::string::npos && viSelMCTriggersMu_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
-	    if(vsSelMCTriggersMu_singleLepCalc->at(itrig).find(string_ORc) != std::string::npos && viSelMCTriggersMu_singleLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+	  for(unsigned int itrig=0; itrig < vsSelMCTriggersMu_MultiLepCalc->size(); itrig++){
+	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(string_a) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(string_b) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+            if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(string_c) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+            if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(string_d) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+            if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(string_e) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(string_ORb) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
+	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(string_ORc) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCPastTrigger = 1;
 	  }
 	  // Cut based tight id
 	  if (fabs(lepeta) < 2.10 && fabs(lepeta) > 1.20) {
@@ -992,13 +1010,13 @@ void step1::Loop()
 	  std::string string_d = "Ele15_IsoVVVL_PFHT600";
 	  std::string string_ORa = "Ele35_WPTight_Gsf";
 	  std::string string_ORb = "Ele38_WPTight_Gsf";
-	  for(unsigned int itrig=0; itrig < vsSelTriggersEl_singleLepCalc->size(); itrig++){
-	    if(vsSelTriggersEl_singleLepCalc->at(itrig).find(string_a) != std::string::npos && viSelTriggersEl_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-	    if(vsSelTriggersEl_singleLepCalc->at(itrig).find(string_b) != std::string::npos && viSelTriggersEl_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-            if(vsSelTriggersEl_singleLepCalc->at(itrig).find(string_c) != std::string::npos && viSelTriggersEl_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-            if(vsSelTriggersEl_singleLepCalc->at(itrig).find(string_d) != std::string::npos && viSelTriggersEl_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-	    if(vsSelTriggersEl_singleLepCalc->at(itrig).find(string_ORa) != std::string::npos && viSelTriggersEl_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-	    if(vsSelTriggersEl_singleLepCalc->at(itrig).find(string_ORb) != std::string::npos && viSelTriggersEl_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+	  for(unsigned int itrig=0; itrig < vsSelTriggersEl_MultiLepCalc->size(); itrig++){
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(string_a) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(string_b) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+            if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(string_c) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+            if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(string_d) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(string_ORa) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(string_ORb) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
 	  }
 	}
 
@@ -1012,14 +1030,14 @@ void step1::Loop()
 	  std::string string_e = "Mu15_IsoVVVL_PFHT600";
 	  std::string string_ORb = "Mu50";
 	  std::string string_ORc = "TkMu50";
-	  for(unsigned int itrig=0; itrig < vsSelTriggersMu_singleLepCalc->size(); itrig++){
-	    if(vsSelTriggersMu_singleLepCalc->at(itrig).find(string_a) != std::string::npos && viSelTriggersMu_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-	    if(vsSelTriggersMu_singleLepCalc->at(itrig).find(string_b) != std::string::npos && viSelTriggersMu_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-            if(vsSelTriggersMu_singleLepCalc->at(itrig).find(string_c) != std::string::npos && viSelTriggersMu_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-            if(vsSelTriggersMu_singleLepCalc->at(itrig).find(string_d) != std::string::npos && viSelTriggersMu_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-            if(vsSelTriggersMu_singleLepCalc->at(itrig).find(string_e) != std::string::npos && viSelTriggersMu_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-	    if(vsSelTriggersMu_singleLepCalc->at(itrig).find(string_ORb) != std::string::npos && viSelTriggersMu_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
-	    if(vsSelTriggersMu_singleLepCalc->at(itrig).find(string_ORc) != std::string::npos && viSelTriggersMu_singleLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+	  for(unsigned int itrig=0; itrig < vsSelTriggersMu_MultiLepCalc->size(); itrig++){
+	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(string_a) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(string_b) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+            if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(string_c) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+            if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(string_d) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+            if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(string_e) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(string_ORb) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
+	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(string_ORc) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataPastTrigger = 1;
 	  }
 	}
 	MCPastTrigger = 1;
@@ -1038,9 +1056,9 @@ void step1::Loop()
 
       if(isMadgraphBkg){
 	// Piece-wise splice with a flat line. Uncertainty from upper/lower error bar fits
-	HTSF_Pol = poly2->Eval(HTfromHEPUEP_singleLepCalc);
-	HTSF_PolUp = poly2U->Eval(HTfromHEPUEP_singleLepCalc);
-	HTSF_PolDn = poly2D->Eval(HTfromHEPUEP_singleLepCalc);
+	HTSF_Pol = poly2->Eval(HTfromHEPUEP_MultiLepCalc);
+	HTSF_PolUp = poly2U->Eval(HTfromHEPUEP_MultiLepCalc);
+	HTSF_PolDn = poly2D->Eval(HTfromHEPUEP_MultiLepCalc);
       }
 
       // ----------------------------------------------------------------------------
@@ -1052,7 +1070,6 @@ void step1::Loop()
       vector<pair<double,int>> jetptindpair;
 
       for(unsigned int ijet=0; ijet < theJetPt_JetSubCalc->size(); ijet++){
-
 	// ----------------------------------------------------------------------------
 	// Basic cuts
 	// ----------------------------------------------------------------------------
@@ -1117,15 +1134,15 @@ void step1::Loop()
       double lepphi;
       if (isMuon){ 
 	lepM = 0.105658367;
-	lepphi = muPhi_singleLepCalc->at(0);
-	lepton_lv.SetPtEtaPhiM(muPt_singleLepCalc->at(0),muEta_singleLepCalc->at(0),muPhi_singleLepCalc->at(0),lepM);
+	lepphi = muPhi_MultiLepCalc->at(0);
+	lepton_lv.SetPtEtaPhiM(muPt_MultiLepCalc->at(0),muEta_MultiLepCalc->at(0),muPhi_MultiLepCalc->at(0),lepM);
       }
       else{
 	lepM = 0.00051099891;
-	lepphi = elPhi_singleLepCalc->at(0);
-	lepton_lv.SetPtEtaPhiM(elPt_singleLepCalc->at(0),elEta_singleLepCalc->at(0),elPhi_singleLepCalc->at(0),lepM);
+	lepphi = elPhi_MultiLepCalc->at(0);
+	lepton_lv.SetPtEtaPhiM(elPt_MultiLepCalc->at(0),elEta_MultiLepCalc->at(0),elPhi_MultiLepCalc->at(0),lepM);
       }      
-      MT_lepMet = sqrt(2*leppt*corr_met_singleLepCalc*(1 - cos(lepphi - corr_met_phi_singleLepCalc)));
+      MT_lepMet = sqrt(2*leppt*corr_met_MultiLepCalc*(1 - cos(lepphi - corr_met_phi_MultiLepCalc)));
 
       // ----------------------------------------------------------------------------
       // Loop over AK8 jets for calculations and pt ordering pair
@@ -1134,7 +1151,6 @@ void step1::Loop()
       NJetsAK8_JetSubCalc = 0;
       vector<pair<double,int>> jetak8ptindpair;      
       for(unsigned int ijet=0; ijet < theJetAK8Pt_JetSubCalc->size(); ijet++){
-
         // ----------------------------------------------------------------------------                                  
         // Basic cuts                                                                                                    
         // ----------------------------------------------------------------------------                                  
@@ -1151,7 +1167,7 @@ void step1::Loop()
         jetak8ptindpair.push_back(std::make_pair(theJetAK8Pt_JetSubCalc->at(ijet),ijet));
 	
       }
-            
+ 
       // ----------------------------------------------------------------------------
       // Apply kinematic cuts
       // ----------------------------------------------------------------------------
@@ -1160,7 +1176,7 @@ void step1::Loop()
       if(AK4HT >= htCut){npass_ht+=1;isPastHTCut=1;}
       
       int isPastMETcut = 0;
-      if(corr_met_singleLepCalc > metCut){npass_met+=1;isPastMETcut=1;}
+      if(corr_met_MultiLepCalc > metCut){npass_met+=1;isPastMETcut=1;}
 
       int isPastLepPtCut = 0;
       if(leppt > lepPtCut){npass_lepPt+=1;isPastLepPtCut=1;}
@@ -1174,7 +1190,6 @@ void step1::Loop()
       
       int isPastNjetsCut = 0;
       if(NJets_JetSubCalc >= njetsCut){npass_Njets+=1;isPastNjetsCut=1;}
-
       // ----------------------------------------------------------------------------
       // Skip failing events
       // ----------------------------------------------------------------------------
@@ -1189,7 +1204,7 @@ void step1::Loop()
       ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////      
 
       AK4HTpMETpLepPt = 0; //ST
-      AK4HTpMETpLepPt = AK4HT + corr_met_singleLepCalc + leppt;
+      AK4HTpMETpLepPt = AK4HT + corr_met_MultiLepCalc + leppt;
       
       // ----------------------------------------------------------------------------
       // Combine lepton variables into one set
@@ -1198,22 +1213,22 @@ void step1::Loop()
       // ******** MAYBE NEED SOME OTHERS?
 //     std::cout<<"========"<<std::endl;
       if(isElectron){
-	leptonPt_singleLepCalc = leppt;
-	leptonEta_singleLepCalc = lepeta;
-	leptonPhi_singleLepCalc = elPhi_singleLepCalc->at(0);
-	leptonEnergy_singleLepCalc = elEnergy_singleLepCalc->at(0);
-	leptonMiniIso_singleLepCalc = elMiniIso_singleLepCalc->at(0);
-	leptonMVAValue_singleLepCalc = elMVAValue_singleLepCalc->at(0);
-// 	std::cout<<"elMother_id_singleLepCalc : "<<elMother_id_singleLepCalc->at(0)<<std::endl;
+	leptonPt_MultiLepCalc = leppt;
+	leptonEta_MultiLepCalc = lepeta;
+	leptonPhi_MultiLepCalc = elPhi_MultiLepCalc->at(0);
+	leptonEnergy_MultiLepCalc = elEnergy_MultiLepCalc->at(0);
+	leptonMiniIso_MultiLepCalc = elMiniIso_MultiLepCalc->at(0);
+//	leptonMVAValue_MultiLepCalc = elMVAValue_MultiLepCalc->at(0);
+// 	std::cout<<"elMother_id_MultiLepCalc : "<<elMother_id_MultiLepCalc->at(0)<<std::endl;
       }
       if(isMuon){
-	leptonPt_singleLepCalc = leppt;
-	leptonEta_singleLepCalc = lepeta;
-	leptonPhi_singleLepCalc = muPhi_singleLepCalc->at(0);
-	leptonEnergy_singleLepCalc = muEnergy_singleLepCalc->at(0);
-	leptonMiniIso_singleLepCalc = muMiniIso_singleLepCalc->at(0);
-	leptonMVAValue_singleLepCalc = -99.9;
-// 	std::cout<<"muMother_id_singleLepCalc : "<<muMother_id_singleLepCalc->at(0)<<std::endl;	
+	leptonPt_MultiLepCalc = leppt;
+	leptonEta_MultiLepCalc = lepeta;
+	leptonPhi_MultiLepCalc = muPhi_MultiLepCalc->at(0);
+	leptonEnergy_MultiLepCalc = muEnergy_MultiLepCalc->at(0);
+	leptonMiniIso_MultiLepCalc = muMiniIso_MultiLepCalc->at(0);
+	leptonMVAValue_MultiLepCalc = -99.9;
+// 	std::cout<<"muMother_id_MultiLepCalc : "<<muMother_id_MultiLepCalc->at(0)<<std::endl;	
       }
 
       // ----------------------------------------------------------------------------
@@ -1221,11 +1236,10 @@ void step1::Loop()
       // ----------------------------------------------------------------------------
 
 
-
       // **** LOTS MORE TO ORDER PROBABLY. OR MAYBE WE DON'T NEED TO ORDER AT ALL.....
       //Pt ordering for AK8
       std::sort(jetak8ptindpair.begin(), jetak8ptindpair.end(), comparepair);
-
+      
       theJetAK8Pt_JetSubCalc_PtOrdered.clear();
       theJetAK8Eta_JetSubCalc_PtOrdered.clear();
       theJetAK8Phi_JetSubCalc_PtOrdered.clear();
@@ -1242,7 +1256,7 @@ void step1::Loop()
       theJetAK8NjettinessTau2_JetSubCalc_PtOrdered.clear();
       theJetAK8NjettinessTau3_JetSubCalc_PtOrdered.clear();
       theJetAK8Indx_Wtagged.clear();
-
+ 
       for(unsigned int ijet=0; ijet < jetak8ptindpair.size(); ijet++){
       	theJetAK8Pt_JetSubCalc_PtOrdered.push_back(theJetAK8Pt_JetSubCalc->at(jetak8ptindpair[ijet].second));
       	theJetAK8Eta_JetSubCalc_PtOrdered.push_back(theJetAK8Eta_JetSubCalc->at(jetak8ptindpair[ijet].second));
@@ -1294,7 +1308,6 @@ void step1::Loop()
       }
       
       for(unsigned int ijet=0; ijet < theJetAK8Pt_JetSubCalc_PtOrdered.size(); ijet++){
-
 	// ----------------------------------------------------------------------------
 	// AK8 - lepton and AK8 -- AK8 associations
 	// ----------------------------------------------------------------------------
@@ -1611,46 +1624,46 @@ void step1::Loop()
       pdfWeights.clear();
       if(isSig){
 	// SEEMS TO APPLY TO ALL B2G MG+PYTHIA SIGNALS. LEADING ORDER 4-FLAVOR PDF
-	for(unsigned int i = 0; i < LHEweightids_singleLepCalc->size(); i++){
-	  if(LHEweightids_singleLepCalc->at(i) > 1 && LHEweightids_singleLepCalc->at(i) < 10){
-	    if(LHEweightids_singleLepCalc->at(i) == 6 || LHEweightids_singleLepCalc->at(i) == 8) continue;
-	    renorm.push_back(LHEweights_singleLepCalc->at(i));
-	    renormWeights.push_back(LHEweights_singleLepCalc->at(i));
+	for(unsigned int i = 0; i < LHEweightids_MultiLepCalc->size(); i++){
+	  if(LHEweightids_MultiLepCalc->at(i) > 1 && LHEweightids_MultiLepCalc->at(i) < 10){
+	    if(LHEweightids_MultiLepCalc->at(i) == 6 || LHEweightids_MultiLepCalc->at(i) == 8) continue;
+	    renorm.push_back(LHEweights_MultiLepCalc->at(i));
+	    renormWeights.push_back(LHEweights_MultiLepCalc->at(i));
 	  }
-	  if(LHEweightids_singleLepCalc->at(i) > 111 && LHEweightids_singleLepCalc->at(i) < 212){
-	    pdf.push_back(LHEweights_singleLepCalc->at(i));	    
-	    pdfWeights.push_back(LHEweights_singleLepCalc->at(i));	    
+	  if(LHEweightids_MultiLepCalc->at(i) > 111 && LHEweightids_MultiLepCalc->at(i) < 212){
+	    pdf.push_back(LHEweights_MultiLepCalc->at(i));	    
+	    pdfWeights.push_back(LHEweights_MultiLepCalc->at(i));	    
 	  }
 	}
       }
       else if(isMadgraphBkg){
 	// SEEMS TO APPLY TO OTHER MG+PYTHIA BACKGROUNDS. LEADING ORDER 5-FLAVOR PDF
-	for(unsigned int i = 0; i < LHEweightids_singleLepCalc->size(); i++){
-	  if(LHEweightids_singleLepCalc->at(i) > 1 && LHEweightids_singleLepCalc->at(i) < 10){
-	    if(LHEweightids_singleLepCalc->at(i) == 6 || LHEweightids_singleLepCalc->at(i) == 8) continue;
-	    renorm.push_back(LHEweights_singleLepCalc->at(i));
-	    renormWeights.push_back(LHEweights_singleLepCalc->at(i));
+	for(unsigned int i = 0; i < LHEweightids_MultiLepCalc->size(); i++){
+	  if(LHEweightids_MultiLepCalc->at(i) > 1 && LHEweightids_MultiLepCalc->at(i) < 10){
+	    if(LHEweightids_MultiLepCalc->at(i) == 6 || LHEweightids_MultiLepCalc->at(i) == 8) continue;
+	    renorm.push_back(LHEweights_MultiLepCalc->at(i));
+	    renormWeights.push_back(LHEweights_MultiLepCalc->at(i));
 	  }
-	  if(LHEweightids_singleLepCalc->at(i) > 10 && LHEweightids_singleLepCalc->at(i) < 111){
-	    pdf.push_back(LHEweights_singleLepCalc->at(i));
-	    pdfWeights.push_back(LHEweights_singleLepCalc->at(i));
+	  if(LHEweightids_MultiLepCalc->at(i) > 10 && LHEweightids_MultiLepCalc->at(i) < 111){
+	    pdf.push_back(LHEweights_MultiLepCalc->at(i));
+	    pdfWeights.push_back(LHEweights_MultiLepCalc->at(i));
 	  }
 	}
       }
       else{
 	// SEEMS TO APPLY TO ALL POWHEG AND MC@NLO BACKGROUNDS. NLO PDFs
-	for(unsigned int i = 0; i < LHEweightids_singleLepCalc->size(); i++){
-	  if(LHEweightids_singleLepCalc->at(i) > 1001 && LHEweightids_singleLepCalc->at(i) < 1010){
-	    if(LHEweightids_singleLepCalc->at(i) == 1006 || LHEweightids_singleLepCalc->at(i) == 1008) continue;
-	    renorm.push_back(LHEweights_singleLepCalc->at(i));
-	    renormWeights.push_back(LHEweights_singleLepCalc->at(i));
+	for(unsigned int i = 0; i < LHEweightids_MultiLepCalc->size(); i++){
+	  if(LHEweightids_MultiLepCalc->at(i) > 1001 && LHEweightids_MultiLepCalc->at(i) < 1010){
+	    if(LHEweightids_MultiLepCalc->at(i) == 1006 || LHEweightids_MultiLepCalc->at(i) == 1008) continue;
+	    renorm.push_back(LHEweights_MultiLepCalc->at(i));
+	    renormWeights.push_back(LHEweights_MultiLepCalc->at(i));
 	  }
-	  if(LHEweightids_singleLepCalc->at(i) > 2000 && LHEweightids_singleLepCalc->at(i) < 2101){
-	    pdf.push_back(LHEweights_singleLepCalc->at(i));
-	    pdfWeights.push_back(LHEweights_singleLepCalc->at(i));
+	  if(LHEweightids_MultiLepCalc->at(i) > 2000 && LHEweightids_MultiLepCalc->at(i) < 2101){
+	    pdf.push_back(LHEweights_MultiLepCalc->at(i));
+	    pdfWeights.push_back(LHEweights_MultiLepCalc->at(i));
 	  }
-	  if(LHEweightids_singleLepCalc->at(i) == 2101 || LHEweightids_singleLepCalc->at(i) == 2102){
-	    alphaSWeights.push_back(LHEweights_singleLepCalc->at(i));
+	  if(LHEweightids_MultiLepCalc->at(i) == 2101 || LHEweightids_MultiLepCalc->at(i) == 2102){
+	    alphaSWeights.push_back(LHEweights_MultiLepCalc->at(i));
 	  }
 	}
       }

--- a/step1/step1.cc
+++ b/step1/step1.cc
@@ -82,7 +82,10 @@ void step1::Loop(TString inTreeName, TString outTreeName )
   // Turn on input tree branches
   // ----------------------------------------------------------------------------
   inputTree=(TTree*)inputFile->Get(inTreeName+"/"+inTreeName);
-  if(inputTree->GetEntries()==0) std::cout<<"WARNING! Found 0 events in the tree!!!!"<<std::endl;;
+  if(inputTree->GetEntries()==0) {
+    std::cout<<"WARNING! Found 0 events in the tree!!!!"<<std::endl;;
+    exit(1);
+  }
   Init(inputTree);
 
    if (inputTree == 0) return;

--- a/step1/step1.h
+++ b/step1/step1.h
@@ -68,12 +68,12 @@ public :
    vector<double>  alphaSWeights;
    vector<double>  pdfWeights;
 
-   Float_t         leptonPt_singleLepCalc;
-   Float_t         leptonEta_singleLepCalc;
-   Float_t         leptonPhi_singleLepCalc;
-   Float_t         leptonEnergy_singleLepCalc;
-   Float_t         leptonMVAValue_singleLepCalc;
-   Float_t         leptonMiniIso_singleLepCalc;
+   Float_t         leptonPt_MultiLepCalc;
+   Float_t         leptonEta_MultiLepCalc;
+   Float_t         leptonPhi_MultiLepCalc;
+   Float_t         leptonEnergy_MultiLepCalc;
+   Float_t         leptonMVAValue_MultiLepCalc;
+   Float_t         leptonMiniIso_MultiLepCalc;
 
    Int_t           NJets_JetSubCalc;
    Int_t           NJetsCSV_JetSubCalc;
@@ -148,8 +148,8 @@ public :
    Float_t         topPtWeight13TeV;
 
    // Declaration of leaf types
-   Bool_t          flagBadMu_singleLepCalc;
-   Bool_t          flagDupMu_singleLepCalc;
+   Bool_t          flagBadMu_MultiLepCalc;
+   Bool_t          flagDupMu_MultiLepCalc;
    Bool_t          isBHBH_TpTpCalc;
    Bool_t          isBHTW_TpTpCalc;
    Bool_t          isBWBW_TpTpCalc;
@@ -162,7 +162,7 @@ public :
    Bool_t          isTZBW_TpTpCalc;
    Bool_t          isTZTH_TpTpCalc;
    Bool_t          isTZTZ_TpTpCalc;
-   Bool_t          isTau_singleLepCalc;
+   Bool_t          isTau_MultiLepCalc;
    Int_t           NBsFromTTbar_TTbarMassCalc;
    Int_t           NCharm_TTbarMassCalc;
    Int_t           NExtraBs_TTbarMassCalc;
@@ -170,12 +170,12 @@ public :
    Int_t           NExtraLs_TTbarMassCalc;
    Int_t           NLeptonDecays_TpTpCalc;
    Int_t           NLight_TTbarMassCalc;
-   Int_t           NPartonsfromHEPUEP_singleLepCalc;
+   Int_t           NPartonsfromHEPUEP_MultiLepCalc;
    Int_t           NTotalBs_TTbarMassCalc;
    Int_t           NWdecaysFromTTbar_TTbarMassCalc;
-   Int_t           dataE_singleLepCalc;
-   Int_t           dataM_singleLepCalc;
-   Int_t           genTDLID_singleLepCalc;
+   Int_t           dataE_MultiLepCalc;
+   Int_t           dataM_MultiLepCalc;
+   Int_t           genTDLID_MultiLepCalc;
    Int_t           isTT_TTbarMassCalc;
    Int_t           isTTbb_TTbarMassCalc;
    Int_t           isTTbj_TTbarMassCalc;
@@ -186,57 +186,57 @@ public :
    Int_t           lumi_CommonCalc;
    Int_t           nAllJets_CommonCalc;
    Int_t           nLooseMuons_CommonCalc;
-   Int_t           nPV_singleLepCalc;
-   Int_t           nPileupInteractions_singleLepCalc;
+   Int_t           nPV_MultiLepCalc;
+   Int_t           nPileupInteractions_MultiLepCalc;
    Int_t           nSelBtagJets_CommonCalc;
    Int_t           nSelElectrons_CommonCalc;
    Int_t           nSelJets_CommonCalc;
    Int_t           nTightMuons_CommonCalc;
-   Int_t           nTrueInteractions_singleLepCalc;
+   Int_t           nTrueInteractions_MultiLepCalc;
    Int_t           run_CommonCalc;
    Long64_t        event_CommonCalc;
-   Double_t        AK4HT_jerdn_singleLepCalc;
-   Double_t        AK4HT_jerup_singleLepCalc;
-   Double_t        AK4HT_jesdn_singleLepCalc;
-   Double_t        AK4HT_jesup_singleLepCalc;
-   Double_t        AK4HT_singleLepCalc;
-   Double_t        HTfromHEPUEP_singleLepCalc;
-   Double_t        MCWeight_singleLepCalc;
-   Double_t        corr_met_jerdn_phi_singleLepCalc;
-   Double_t        corr_met_jerdn_singleLepCalc;
-   Double_t        corr_met_jerup_phi_singleLepCalc;
-   Double_t        corr_met_jerup_singleLepCalc;
-   Double_t        corr_met_jesdn_phi_singleLepCalc;
-   Double_t        corr_met_jesdn_singleLepCalc;
-   Double_t        corr_met_jesup_phi_singleLepCalc;
-   Double_t        corr_met_jesup_singleLepCalc;
-   Double_t        corr_met_phi_singleLepCalc;
-   Double_t        corr_met_singleLepCalc;
-   Double_t        corr_metnohf_phi_singleLepCalc;
-   Double_t        corr_metnohf_singleLepCalc;
-   Double_t        genTDLEnergy_singleLepCalc;
-   Double_t        genTDLEta_singleLepCalc;
-   Double_t        genTDLPhi_singleLepCalc;
-   Double_t        genTDLPt_singleLepCalc;
-   Double_t        met_phi_singleLepCalc;
-   Double_t        met_singleLepCalc;
-   Double_t        metnohf_phi_singleLepCalc;
-   Double_t        metnohf_singleLepCalc;
+   Double_t        AK4HT_jerdn_MultiLepCalc;
+   Double_t        AK4HT_jerup_MultiLepCalc;
+   Double_t        AK4HT_jesdn_MultiLepCalc;
+   Double_t        AK4HT_jesup_MultiLepCalc;
+   Double_t        AK4HT_MultiLepCalc;
+   Double_t        HTfromHEPUEP_MultiLepCalc;
+   Double_t        MCWeight_MultiLepCalc;
+   Double_t        corr_met_jerdn_phi_MultiLepCalc;
+   Double_t        corr_met_jerdn_MultiLepCalc;
+   Double_t        corr_met_jerup_phi_MultiLepCalc;
+   Double_t        corr_met_jerup_MultiLepCalc;
+   Double_t        corr_met_jesdn_phi_MultiLepCalc;
+   Double_t        corr_met_jesdn_MultiLepCalc;
+   Double_t        corr_met_jesup_phi_MultiLepCalc;
+   Double_t        corr_met_jesup_MultiLepCalc;
+   Double_t        corr_met_phi_MultiLepCalc;
+   Double_t        corr_met_MultiLepCalc;
+   Double_t        corr_metnohf_phi_MultiLepCalc;
+   Double_t        corr_metnohf_MultiLepCalc;
+   Double_t        genTDLEnergy_MultiLepCalc;
+   Double_t        genTDLEta_MultiLepCalc;
+   Double_t        genTDLPhi_MultiLepCalc;
+   Double_t        genTDLPt_MultiLepCalc;
+   Double_t        met_phi_MultiLepCalc;
+   Double_t        met_MultiLepCalc;
+   Double_t        metnohf_phi_MultiLepCalc;
+   Double_t        metnohf_MultiLepCalc;
    Double_t        theJetHT_JetSubCalc;
    Double_t        theJetLeadPt_JetSubCalc;
    Double_t        theJetSubLeadPt_JetSubCalc;
    Double_t        ttbarMass_TTbarMassCalc;
-   vector<int>     *AK4JetBTag_bSFdn_singleLepCalc;
-   vector<int>     *AK4JetBTag_bSFup_singleLepCalc;
-   vector<int>     *AK4JetBTag_lSFdn_singleLepCalc;
-   vector<int>     *AK4JetBTag_lSFup_singleLepCalc;
-   vector<int>     *AK4JetBTag_singleLepCalc;
-   vector<int>     *AK4JetFlav_singleLepCalc;
+   vector<int>     *AK4JetBTag_bSFdn_MultiLepCalc;
+   vector<int>     *AK4JetBTag_bSFup_MultiLepCalc;
+   vector<int>     *AK4JetBTag_lSFdn_MultiLepCalc;
+   vector<int>     *AK4JetBTag_lSFup_MultiLepCalc;
+   vector<int>     *AK4JetBTag_MultiLepCalc;
+   vector<int>     *AK4JetFlav_MultiLepCalc;
    vector<int>     *HadronicVHtID_JetSubCalc;
    vector<int>     *HadronicVHtStatus_JetSubCalc;
    vector<int>     *HdecayID_TpTpCalc;
    vector<int>     *HdecayIndex_TpTpCalc;
-   vector<int>     *LHEweightids_singleLepCalc;
+   vector<int>     *LHEweightids_MultiLepCalc;
    vector<int>     *LeptonID_TpTpCalc;
    vector<int>     *LeptonParentID_TpTpCalc;
    vector<int>     *WdecayID_TpTpCalc;
@@ -252,60 +252,60 @@ public :
    vector<int>     *decorr_largest_DeepAK8Calc;
    vector<int>     *dnn_largest_BestCalc;
    vector<int>     *dnn_largest_DeepAK8Calc;
-   vector<int>     *elChargeConsistent_singleLepCalc;
-   vector<int>     *elCharge_singleLepCalc;
-   vector<int>     *elCtfCharge_singleLepCalc;
-   vector<int>     *elGsfCharge_singleLepCalc;
-   vector<int>     *elIsEBEE_singleLepCalc;
-   vector<int>     *elIsMVALooseIso_singleLepCalc;
-   vector<int>     *elIsMVALoose_singleLepCalc;
-   vector<int>     *elIsMVATightIso_singleLepCalc;
-   vector<int>     *elIsMVATight_singleLepCalc;
-   vector<int>     *elMHits_singleLepCalc;
-   vector<int>     *elMatched_singleLepCalc;
-   vector<int>     *elMother_id_singleLepCalc;
-   vector<int>     *elMother_status_singleLepCalc;
-   vector<int>     *elNotConversion_singleLepCalc;
-   vector<int>     *elNumberOfMothers_singleLepCalc;
-   vector<int>     *elPdgId_singleLepCalc;
-   vector<int>     *elScPixCharge_singleLepCalc;
-   vector<int>     *elStatus_singleLepCalc;
-   vector<int>     *elVtxFitConv_singleLepCalc;
-   vector<int>     *electron_1_hltmatched_singleLepCalc;
-   vector<int>     *genBSLID_singleLepCalc;
-   vector<int>     *genID_singleLepCalc;
-   vector<int>     *genIndex_singleLepCalc;
-   vector<int>     *genMotherID_singleLepCalc;
-   vector<int>     *genMotherIndex_singleLepCalc;
-   vector<int>     *genStatus_singleLepCalc;
+   vector<int>     *elChargeConsistent_MultiLepCalc;
+   vector<int>     *elCharge_MultiLepCalc;
+   vector<int>     *elCtfCharge_MultiLepCalc;
+   vector<int>     *elGsfCharge_MultiLepCalc;
+   vector<int>     *elIsEBEE_MultiLepCalc;
+   vector<int>     *elIsMVALooseIso_MultiLepCalc;
+   vector<int>     *elIsMVALoose_MultiLepCalc;
+   vector<int>     *elIsMVATightIso_MultiLepCalc;
+   vector<int>     *elIsMVATight_MultiLepCalc;
+   vector<int>     *elMHits_MultiLepCalc;
+   vector<int>     *elMatched_MultiLepCalc;
+   vector<int>     *elMother_id_MultiLepCalc;
+   vector<int>     *elMother_status_MultiLepCalc;
+   vector<int>     *elNotConversion_MultiLepCalc;
+   vector<int>     *elNumberOfMothers_MultiLepCalc;
+   vector<int>     *elPdgId_MultiLepCalc;
+   vector<int>     *elScPixCharge_MultiLepCalc;
+   vector<int>     *elStatus_MultiLepCalc;
+   vector<int>     *elVtxFitConv_MultiLepCalc;
+   vector<int>     *electron_1_hltmatched_MultiLepCalc;
+   vector<int>     *genBSLID_MultiLepCalc;
+   vector<int>     *genID_MultiLepCalc;
+   vector<int>     *genIndex_MultiLepCalc;
+   vector<int>     *genMotherID_MultiLepCalc;
+   vector<int>     *genMotherIndex_MultiLepCalc;
+   vector<int>     *genStatus_MultiLepCalc;
    vector<int>     *genTtbarIdCategory_TTbarMassCalc;
    vector<int>     *maxProb_JetSubCalc;
-   vector<int>     *muCharge_singleLepCalc;
-   vector<int>     *muGlobal_singleLepCalc;
-   vector<int>     *muIsGlobalHighPt_singleLepCalc;
-   vector<int>     *muIsLoose_singleLepCalc;
-   vector<int>     *muIsMediumPrompt_singleLepCalc;
-   vector<int>     *muIsMedium_singleLepCalc;
-   vector<int>     *muIsMiniIsoLoose_singleLepCalc;
-   vector<int>     *muIsMiniIsoMedium_singleLepCalc;
-   vector<int>     *muIsMiniIsoTight_singleLepCalc;
-   vector<int>     *muIsMiniIsoVeryTight_singleLepCalc;
-   vector<int>     *muIsMvaLoose_singleLepCalc;
-   vector<int>     *muIsMvaMedium_singleLepCalc;
-   vector<int>     *muIsMvaTight_singleLepCalc;
-   vector<int>     *muIsTight_singleLepCalc;
-   vector<int>     *muIsTrkHighPt_singleLepCalc;
-   vector<int>     *muMatched_singleLepCalc;
-   vector<int>     *muMother_id_singleLepCalc;
-   vector<int>     *muMother_status_singleLepCalc;
-   vector<int>     *muNMatchedStations_singleLepCalc;
-   vector<int>     *muNTrackerLayers_singleLepCalc;
-   vector<int>     *muNValMuHits_singleLepCalc;
-   vector<int>     *muNValPixelHits_singleLepCalc;
-   vector<int>     *muNumberOfMothers_singleLepCalc;
-   vector<int>     *muPdgId_singleLepCalc;
-   vector<int>     *muStatus_singleLepCalc;
-   vector<int>     *muon_1_hltmatched_singleLepCalc;
+   vector<int>     *muCharge_MultiLepCalc;
+   vector<int>     *muGlobal_MultiLepCalc;
+   vector<int>     *muIsGlobalHighPt_MultiLepCalc;
+   vector<int>     *muIsLoose_MultiLepCalc;
+   vector<int>     *muIsMediumPrompt_MultiLepCalc;
+   vector<int>     *muIsMedium_MultiLepCalc;
+   vector<int>     *muIsMiniIsoLoose_MultiLepCalc;
+   vector<int>     *muIsMiniIsoMedium_MultiLepCalc;
+   vector<int>     *muIsMiniIsoTight_MultiLepCalc;
+   vector<int>     *muIsMiniIsoVeryTight_MultiLepCalc;
+   vector<int>     *muIsMvaLoose_MultiLepCalc;
+   vector<int>     *muIsMvaMedium_MultiLepCalc;
+   vector<int>     *muIsMvaTight_MultiLepCalc;
+   vector<int>     *muIsTight_MultiLepCalc;
+   vector<int>     *muIsTrkHighPt_MultiLepCalc;
+   vector<int>     *muMatched_MultiLepCalc;
+   vector<int>     *muMother_id_MultiLepCalc;
+   vector<int>     *muMother_status_MultiLepCalc;
+   vector<int>     *muNMatchedStations_MultiLepCalc;
+   vector<int>     *muNTrackerLayers_MultiLepCalc;
+   vector<int>     *muNValMuHits_MultiLepCalc;
+   vector<int>     *muNValPixelHits_MultiLepCalc;
+   vector<int>     *muNumberOfMothers_MultiLepCalc;
+   vector<int>     *muPdgId_MultiLepCalc;
+   vector<int>     *muStatus_MultiLepCalc;
+   vector<int>     *muon_1_hltmatched_MultiLepCalc;
    vector<int>     *quarkID_TpTpCalc;
    vector<int>     *tPrimeID_TpTpCalc;
    vector<int>     *tPrimeNDaughters_TpTpCalc;
@@ -333,45 +333,45 @@ public :
    vector<int>     *topID_TTbarMassCalc;
    vector<int>     *topWID_TTbarMassCalc;
    vector<int>     *topbID_TTbarMassCalc;
-   vector<int>     *viSelMCTriggersEl_singleLepCalc;
-   vector<int>     *viSelMCTriggersMu_singleLepCalc;
-   vector<int>     *viSelTriggersEl_singleLepCalc;
-   vector<int>     *viSelTriggersMu_singleLepCalc;
-   vector<double>  *AK4JetBDeepCSVb_singleLepCalc;
-   vector<double>  *AK4JetBDeepCSVbb_singleLepCalc;
-   vector<double>  *AK4JetBDeepCSVc_singleLepCalc;
-   vector<double>  *AK4JetBDeepCSVudsg_singleLepCalc;
-   vector<double>  *AK4JetBDisc_singleLepCalc;
-   vector<double>  *AK4JetEnergy_jerdn_singleLepCalc;
-   vector<double>  *AK4JetEnergy_jerup_singleLepCalc;
-   vector<double>  *AK4JetEnergy_jesdn_singleLepCalc;
-   vector<double>  *AK4JetEnergy_jesup_singleLepCalc;
-   vector<double>  *AK4JetEnergy_singleLepCalc;
-   vector<double>  *AK4JetEta_singleLepCalc;
-   vector<double>  *AK4JetPhi_singleLepCalc;
-   vector<double>  *AK4JetPt_jerdn_singleLepCalc;
-   vector<double>  *AK4JetPt_jerup_singleLepCalc;
-   vector<double>  *AK4JetPt_jesdn_singleLepCalc;
-   vector<double>  *AK4JetPt_jesup_singleLepCalc;
-   vector<double>  *AK4JetPt_singleLepCalc;
+   vector<int>     *viSelMCTriggersEl_MultiLepCalc;
+   vector<int>     *viSelMCTriggersMu_MultiLepCalc;
+   vector<int>     *viSelTriggersEl_MultiLepCalc;
+   vector<int>     *viSelTriggersMu_MultiLepCalc;
+   vector<double>  *AK4JetBDeepCSVb_MultiLepCalc;
+   vector<double>  *AK4JetBDeepCSVbb_MultiLepCalc;
+   vector<double>  *AK4JetBDeepCSVc_MultiLepCalc;
+   vector<double>  *AK4JetBDeepCSVudsg_MultiLepCalc;
+   vector<double>  *AK4JetBDisc_MultiLepCalc;
+   vector<double>  *AK4JetEnergy_jerdn_MultiLepCalc;
+   vector<double>  *AK4JetEnergy_jerup_MultiLepCalc;
+   vector<double>  *AK4JetEnergy_jesdn_MultiLepCalc;
+   vector<double>  *AK4JetEnergy_jesup_MultiLepCalc;
+   vector<double>  *AK4JetEnergy_MultiLepCalc;
+   vector<double>  *AK4JetEta_MultiLepCalc;
+   vector<double>  *AK4JetPhi_MultiLepCalc;
+   vector<double>  *AK4JetPt_jerdn_MultiLepCalc;
+   vector<double>  *AK4JetPt_jerup_MultiLepCalc;
+   vector<double>  *AK4JetPt_jesdn_MultiLepCalc;
+   vector<double>  *AK4JetPt_jesup_MultiLepCalc;
+   vector<double>  *AK4JetPt_MultiLepCalc;
    vector<double>  *AK8JetCSV_BestCalc;
-   vector<double>  *AK8JetCSV_singleLepCalc;
+   vector<double>  *AK8JetCSV_MultiLepCalc;
    vector<double>  *AK8JetEnergy_BestCalc;
-   vector<double>  *AK8JetEnergy_jerdn_singleLepCalc;
-   vector<double>  *AK8JetEnergy_jerup_singleLepCalc;
-   vector<double>  *AK8JetEnergy_jesdn_singleLepCalc;
-   vector<double>  *AK8JetEnergy_jesup_singleLepCalc;
-   vector<double>  *AK8JetEnergy_singleLepCalc;
+   vector<double>  *AK8JetEnergy_jerdn_MultiLepCalc;
+   vector<double>  *AK8JetEnergy_jerup_MultiLepCalc;
+   vector<double>  *AK8JetEnergy_jesdn_MultiLepCalc;
+   vector<double>  *AK8JetEnergy_jesup_MultiLepCalc;
+   vector<double>  *AK8JetEnergy_MultiLepCalc;
    vector<double>  *AK8JetEta_BestCalc;
-   vector<double>  *AK8JetEta_singleLepCalc;
+   vector<double>  *AK8JetEta_MultiLepCalc;
    vector<double>  *AK8JetPhi_BestCalc;
-   vector<double>  *AK8JetPhi_singleLepCalc;
+   vector<double>  *AK8JetPhi_MultiLepCalc;
    vector<double>  *AK8JetPt_BestCalc;
-   vector<double>  *AK8JetPt_jerdn_singleLepCalc;
-   vector<double>  *AK8JetPt_jerup_singleLepCalc;
-   vector<double>  *AK8JetPt_jesdn_singleLepCalc;
-   vector<double>  *AK8JetPt_jesup_singleLepCalc;
-   vector<double>  *AK8JetPt_singleLepCalc;
+   vector<double>  *AK8JetPt_jerdn_MultiLepCalc;
+   vector<double>  *AK8JetPt_jerup_MultiLepCalc;
+   vector<double>  *AK8JetPt_jesdn_MultiLepCalc;
+   vector<double>  *AK8JetPt_jesup_MultiLepCalc;
+   vector<double>  *AK8JetPt_MultiLepCalc;
    vector<double>  *FWmoment1H_BestCalc;
    vector<double>  *FWmoment1W_BestCalc;
    vector<double>  *FWmoment1Z_BestCalc;
@@ -408,7 +408,7 @@ public :
    vector<double>  *HdecayEta_TpTpCalc;
    vector<double>  *HdecayPhi_TpTpCalc;
    vector<double>  *HdecayPt_TpTpCalc;
-   vector<double>  *LHEweights_singleLepCalc;
+   vector<double>  *LHEweights_MultiLepCalc;
    vector<double>  *LeptonEnergy_TpTpCalc;
    vector<double>  *LeptonEta_TpTpCalc;
    vector<double>  *LeptonPhi_TpTpCalc;
@@ -466,69 +466,69 @@ public :
    vector<double>  *dnn_W_DeepAK8Calc;
    vector<double>  *dnn_Z_BestCalc;
    vector<double>  *dnn_Z_DeepAK8Calc;
-   vector<double>  *elAEff_singleLepCalc;
-   vector<double>  *elChIso_singleLepCalc;
-   vector<double>  *elD0_singleLepCalc;
-   vector<double>  *elDEtaSCTkAtVtx_singleLepCalc;
-   vector<double>  *elDPhiSCTkAtVtx_singleLepCalc;
-   vector<double>  *elDR03TkSumPt_singleLepCalc;
-   vector<double>  *elDZ_singleLepCalc;
-   vector<double>  *elDeta_singleLepCalc;
-   vector<double>  *elDphi_singleLepCalc;
-   vector<double>  *elDxy_singleLepCalc;
-   vector<double>  *elEcalPFClusterIso_singleLepCalc;
-   vector<double>  *elEnergy_singleLepCalc;
-   vector<double>  *elEtaVtx_singleLepCalc;
-   vector<double>  *elEta_singleLepCalc;
-   vector<double>  *elGen_Reco_dr_singleLepCalc;
-   vector<double>  *elHcalPFClusterIso_singleLepCalc;
-   vector<double>  *elHoE_singleLepCalc;
-   vector<double>  *elIsLooseBarrel_singleLepCalc;
-   vector<double>  *elIsLooseEndCap_singleLepCalc;
-   vector<double>  *elIsMediumBarrel_singleLepCalc;
-   vector<double>  *elIsMediumEndCap_singleLepCalc;
-   vector<double>  *elIsTightBarrel_singleLepCalc;
-   vector<double>  *elIsTightEndCap_singleLepCalc;
-   vector<double>  *elIsVetoBarrel_singleLepCalc;
-   vector<double>  *elIsVetoEndCap_singleLepCalc;
-   vector<double>  *elMVAValue_iso_singleLepCalc;
-   vector<double>  *elMVAValue_singleLepCalc;
-   vector<double>  *elMatchedEnergy_singleLepCalc;
-   vector<double>  *elMatchedEta_singleLepCalc;
-   vector<double>  *elMatchedPhi_singleLepCalc;
-   vector<double>  *elMatchedPt_singleLepCalc;
-   vector<double>  *elMiniIso_singleLepCalc;
-   vector<double>  *elMother_energy_singleLepCalc;
-   vector<double>  *elMother_eta_singleLepCalc;
-   vector<double>  *elMother_phi_singleLepCalc;
-   vector<double>  *elMother_pt_singleLepCalc;
-   vector<double>  *elNhIso_singleLepCalc;
-   vector<double>  *elOoemoop_singleLepCalc;
-   vector<double>  *elPFEta_singleLepCalc;
-   vector<double>  *elPFPhi_singleLepCalc;
-   vector<double>  *elPhIso_singleLepCalc;
-   vector<double>  *elPhiVtx_singleLepCalc;
-   vector<double>  *elPhi_singleLepCalc;
-   vector<double>  *elPt_singleLepCalc;
-   vector<double>  *elRelIso_singleLepCalc;
-   vector<double>  *elRhoIso_singleLepCalc;
-   vector<double>  *elSCE_singleLepCalc;
-   vector<double>  *elSihih_singleLepCalc;
+   vector<double>  *elAEff_MultiLepCalc;
+   vector<double>  *elChIso_MultiLepCalc;
+   vector<double>  *elD0_MultiLepCalc;
+   vector<double>  *elDEtaSCTkAtVtx_MultiLepCalc;
+   vector<double>  *elDPhiSCTkAtVtx_MultiLepCalc;
+   vector<double>  *elDR03TkSumPt_MultiLepCalc;
+   vector<double>  *elDZ_MultiLepCalc;
+   vector<double>  *elDeta_MultiLepCalc;
+   vector<double>  *elDphi_MultiLepCalc;
+   vector<double>  *elDxy_MultiLepCalc;
+   vector<double>  *elEcalPFClusterIso_MultiLepCalc;
+   vector<double>  *elEnergy_MultiLepCalc;
+   vector<double>  *elEtaVtx_MultiLepCalc;
+   vector<double>  *elEta_MultiLepCalc;
+   vector<double>  *elGen_Reco_dr_MultiLepCalc;
+   vector<double>  *elHcalPFClusterIso_MultiLepCalc;
+   vector<double>  *elHoE_MultiLepCalc;
+   vector<double>  *elIsLooseBarrel_MultiLepCalc;
+   vector<double>  *elIsLooseEndCap_MultiLepCalc;
+   vector<double>  *elIsMediumBarrel_MultiLepCalc;
+   vector<double>  *elIsMediumEndCap_MultiLepCalc;
+   vector<double>  *elIsTightBarrel_MultiLepCalc;
+   vector<double>  *elIsTightEndCap_MultiLepCalc;
+   vector<double>  *elIsVetoBarrel_MultiLepCalc;
+   vector<double>  *elIsVetoEndCap_MultiLepCalc;
+   vector<double>  *elMVAValue_iso_MultiLepCalc;
+//   vector<double>  *elMVAValue_MultiLepCalc;
+   vector<double>  *elMatchedEnergy_MultiLepCalc;
+   vector<double>  *elMatchedEta_MultiLepCalc;
+   vector<double>  *elMatchedPhi_MultiLepCalc;
+   vector<double>  *elMatchedPt_MultiLepCalc;
+   vector<double>  *elMiniIso_MultiLepCalc;
+   vector<double>  *elMother_energy_MultiLepCalc;
+   vector<double>  *elMother_eta_MultiLepCalc;
+   vector<double>  *elMother_phi_MultiLepCalc;
+   vector<double>  *elMother_pt_MultiLepCalc;
+   vector<double>  *elNhIso_MultiLepCalc;
+   vector<double>  *elOoemoop_MultiLepCalc;
+   vector<double>  *elPFEta_MultiLepCalc;
+   vector<double>  *elPFPhi_MultiLepCalc;
+   vector<double>  *elPhIso_MultiLepCalc;
+   vector<double>  *elPhiVtx_MultiLepCalc;
+   vector<double>  *elPhi_MultiLepCalc;
+   vector<double>  *elPt_MultiLepCalc;
+   vector<double>  *elRelIso_MultiLepCalc;
+   vector<double>  *elRhoIso_MultiLepCalc;
+   vector<double>  *elSCE_MultiLepCalc;
+   vector<double>  *elSihih_MultiLepCalc;
    vector<double>  *et_BestCalc;
    vector<double>  *eta_BestCalc;
-   vector<double>  *evtWeightsMC_singleLepCalc;
-   vector<double>  *genBSLEnergy_singleLepCalc;
-   vector<double>  *genBSLEta_singleLepCalc;
-   vector<double>  *genBSLPhi_singleLepCalc;
-   vector<double>  *genBSLPt_singleLepCalc;
-   vector<double>  *genEnergy_singleLepCalc;
-   vector<double>  *genEta_singleLepCalc;
-   vector<double>  *genJetEnergy_singleLepCalc;
-   vector<double>  *genJetEta_singleLepCalc;
-   vector<double>  *genJetPhi_singleLepCalc;
-   vector<double>  *genJetPt_singleLepCalc;
-   vector<double>  *genPhi_singleLepCalc;
-   vector<double>  *genPt_singleLepCalc;
+   vector<double>  *evtWeightsMC_MultiLepCalc;
+   vector<double>  *genBSLEnergy_MultiLepCalc;
+   vector<double>  *genBSLEta_MultiLepCalc;
+   vector<double>  *genBSLPhi_MultiLepCalc;
+   vector<double>  *genBSLPt_MultiLepCalc;
+   vector<double>  *genEnergy_MultiLepCalc;
+   vector<double>  *genEta_MultiLepCalc;
+   vector<double>  *genJetEnergy_MultiLepCalc;
+   vector<double>  *genJetEta_MultiLepCalc;
+   vector<double>  *genJetPhi_MultiLepCalc;
+   vector<double>  *genJetPt_MultiLepCalc;
+   vector<double>  *genPhi_MultiLepCalc;
+   vector<double>  *genPt_MultiLepCalc;
    vector<double>  *isotropyH_BestCalc;
    vector<double>  *isotropyW_BestCalc;
    vector<double>  *isotropyZ_BestCalc;
@@ -554,32 +554,32 @@ public :
    vector<double>  *m23_jet_BestCalc;
    vector<double>  *m23top_BestCalc;
    vector<double>  *mass_BestCalc;
-   vector<double>  *muChIso_singleLepCalc;
-   vector<double>  *muChi2_singleLepCalc;
-   vector<double>  *muDxy_singleLepCalc;
-   vector<double>  *muDz_singleLepCalc;
-   vector<double>  *muEnergy_singleLepCalc;
-   vector<double>  *muEta_singleLepCalc;
-   vector<double>  *muGIso_singleLepCalc;
-   vector<double>  *muGen_Reco_dr_singleLepCalc;
-   vector<double>  *muInnerEta_singleLepCalc;
-   vector<double>  *muInnerPhi_singleLepCalc;
-   vector<double>  *muInnerPt_singleLepCalc;
-   vector<double>  *muMatchedEnergy_singleLepCalc;
-   vector<double>  *muMatchedEta_singleLepCalc;
-   vector<double>  *muMatchedPhi_singleLepCalc;
-   vector<double>  *muMatchedPt_singleLepCalc;
-   vector<double>  *muMiniIsoDB_singleLepCalc;
-   vector<double>  *muMiniIso_singleLepCalc;
-   vector<double>  *muMother_energy_singleLepCalc;
-   vector<double>  *muMother_eta_singleLepCalc;
-   vector<double>  *muMother_phi_singleLepCalc;
-   vector<double>  *muMother_pt_singleLepCalc;
-   vector<double>  *muNhIso_singleLepCalc;
-   vector<double>  *muPhi_singleLepCalc;
-   vector<double>  *muPt_singleLepCalc;
-   vector<double>  *muPuIso_singleLepCalc;
-   vector<double>  *muRelIso_singleLepCalc;
+   vector<double>  *muChIso_MultiLepCalc;
+   vector<double>  *muChi2_MultiLepCalc;
+   vector<double>  *muDxy_MultiLepCalc;
+   vector<double>  *muDz_MultiLepCalc;
+   vector<double>  *muEnergy_MultiLepCalc;
+   vector<double>  *muEta_MultiLepCalc;
+   vector<double>  *muGIso_MultiLepCalc;
+   vector<double>  *muGen_Reco_dr_MultiLepCalc;
+   vector<double>  *muInnerEta_MultiLepCalc;
+   vector<double>  *muInnerPhi_MultiLepCalc;
+   vector<double>  *muInnerPt_MultiLepCalc;
+   vector<double>  *muMatchedEnergy_MultiLepCalc;
+   vector<double>  *muMatchedEta_MultiLepCalc;
+   vector<double>  *muMatchedPhi_MultiLepCalc;
+   vector<double>  *muMatchedPt_MultiLepCalc;
+   vector<double>  *muMiniIsoDB_MultiLepCalc;
+   vector<double>  *muMiniIso_MultiLepCalc;
+   vector<double>  *muMother_energy_MultiLepCalc;
+   vector<double>  *muMother_eta_MultiLepCalc;
+   vector<double>  *muMother_phi_MultiLepCalc;
+   vector<double>  *muMother_pt_MultiLepCalc;
+   vector<double>  *muNhIso_MultiLepCalc;
+   vector<double>  *muPhi_MultiLepCalc;
+   vector<double>  *muPt_MultiLepCalc;
+   vector<double>  *muPuIso_MultiLepCalc;
+   vector<double>  *muRelIso_MultiLepCalc;
    vector<double>  *pzOverp_H_BestCalc;
    vector<double>  *pzOverp_W_BestCalc;
    vector<double>  *pzOverp_Z_BestCalc;
@@ -671,16 +671,16 @@ public :
    vector<double>  *topbEta_TTbarMassCalc;
    vector<double>  *topbPhi_TTbarMassCalc;
    vector<double>  *topbPt_TTbarMassCalc;
-   vector<string>  *electron_hltfilters_singleLepCalc;
-   vector<string>  *muon_hltfilters_singleLepCalc;
-   vector<string>  *vsSelMCTriggersEl_singleLepCalc;
-   vector<string>  *vsSelMCTriggersMu_singleLepCalc;
-   vector<string>  *vsSelTriggersEl_singleLepCalc;
-   vector<string>  *vsSelTriggersMu_singleLepCalc;
+   vector<string>  *electron_hltfilters_MultiLepCalc;
+   vector<string>  *muon_hltfilters_MultiLepCalc;
+   vector<string>  *vsSelMCTriggersEl_MultiLepCalc;
+   vector<string>  *vsSelMCTriggersMu_MultiLepCalc;
+   vector<string>  *vsSelTriggersEl_MultiLepCalc;
+   vector<string>  *vsSelTriggersMu_MultiLepCalc;
 
    // List of branches
-   TBranch        *b_flagBadMu_singleLepCalc;   //!
-   TBranch        *b_flagDupMu_singleLepCalc;   //!
+   TBranch        *b_flagBadMu_MultiLepCalc;   //!
+   TBranch        *b_flagDupMu_MultiLepCalc;   //!
    TBranch        *b_isBHBH_TpTpCalc;   //!
    TBranch        *b_isBHTW_TpTpCalc;   //!
    TBranch        *b_isBWBW_TpTpCalc;   //!
@@ -693,7 +693,7 @@ public :
    TBranch        *b_isTZBW_TpTpCalc;   //!
    TBranch        *b_isTZTH_TpTpCalc;   //!
    TBranch        *b_isTZTZ_TpTpCalc;   //!
-   TBranch        *b_isTau_singleLepCalc;   //!
+   TBranch        *b_isTau_MultiLepCalc;   //!
    TBranch        *b_NBsFromTTbar_TTbarMassCalc;   //!
    TBranch        *b_NCharm_TTbarMassCalc;   //!
    TBranch        *b_NExtraBs_TTbarMassCalc;   //!
@@ -701,12 +701,12 @@ public :
    TBranch        *b_NExtraLs_TTbarMassCalc;   //!
    TBranch        *b_NLeptonDecays_TpTpCalc;   //!
    TBranch        *b_NLight_TTbarMassCalc;   //!
-   TBranch        *b_NPartonsfromHEPUEP_singleLepCalc;   //!
+   TBranch        *b_NPartonsfromHEPUEP_MultiLepCalc;   //!
    TBranch        *b_NTotalBs_TTbarMassCalc;   //!
    TBranch        *b_NWdecaysFromTTbar_TTbarMassCalc;   //!
-   TBranch        *b_dataE_singleLepCalc;   //!
-   TBranch        *b_dataM_singleLepCalc;   //!
-   TBranch        *b_genTDLID_singleLepCalc;   //!
+   TBranch        *b_dataE_MultiLepCalc;   //!
+   TBranch        *b_dataM_MultiLepCalc;   //!
+   TBranch        *b_genTDLID_MultiLepCalc;   //!
    TBranch        *b_isTT_TTbarMassCalc;   //!
    TBranch        *b_isTTbb_TTbarMassCalc;   //!
    TBranch        *b_isTTbj_TTbarMassCalc;   //!
@@ -717,57 +717,57 @@ public :
    TBranch        *b_lumi_CommonCalc;   //!
    TBranch        *b_nAllJets_CommonCalc;   //!
    TBranch        *b_nLooseMuons_CommonCalc;   //!
-   TBranch        *b_nPV_singleLepCalc;   //!
-   TBranch        *b_nPileupInteractions_singleLepCalc;   //!
+   TBranch        *b_nPV_MultiLepCalc;   //!
+   TBranch        *b_nPileupInteractions_MultiLepCalc;   //!
    TBranch        *b_nSelBtagJets_CommonCalc;   //!
    TBranch        *b_nSelElectrons_CommonCalc;   //!
    TBranch        *b_nSelJets_CommonCalc;   //!
    TBranch        *b_nTightMuons_CommonCalc;   //!
-   TBranch        *b_nTrueInteractions_singleLepCalc;   //!
+   TBranch        *b_nTrueInteractions_MultiLepCalc;   //!
    TBranch        *b_run_CommonCalc;   //!
    TBranch        *b_event_CommonCalc;   //!
-   TBranch        *b_AK4HT_jerdn_singleLepCalc;   //!
-   TBranch        *b_AK4HT_jerup_singleLepCalc;   //!
-   TBranch        *b_AK4HT_jesdn_singleLepCalc;   //!
-   TBranch        *b_AK4HT_jesup_singleLepCalc;   //!
-   TBranch        *b_AK4HT_singleLepCalc;   //!
-   TBranch        *b_HTfromHEPUEP_singleLepCalc;   //!
-   TBranch        *b_MCWeight_singleLepCalc;   //!
-   TBranch        *b_corr_met_jerdn_phi_singleLepCalc;   //!
-   TBranch        *b_corr_met_jerdn_singleLepCalc;   //!
-   TBranch        *b_corr_met_jerup_phi_singleLepCalc;   //!
-   TBranch        *b_corr_met_jerup_singleLepCalc;   //!
-   TBranch        *b_corr_met_jesdn_phi_singleLepCalc;   //!
-   TBranch        *b_corr_met_jesdn_singleLepCalc;   //!
-   TBranch        *b_corr_met_jesup_phi_singleLepCalc;   //!
-   TBranch        *b_corr_met_jesup_singleLepCalc;   //!
-   TBranch        *b_corr_met_phi_singleLepCalc;   //!
-   TBranch        *b_corr_met_singleLepCalc;   //!
-   TBranch        *b_corr_metnohf_phi_singleLepCalc;   //!
-   TBranch        *b_corr_metnohf_singleLepCalc;   //!
-   TBranch        *b_genTDLEnergy_singleLepCalc;   //!
-   TBranch        *b_genTDLEta_singleLepCalc;   //!
-   TBranch        *b_genTDLPhi_singleLepCalc;   //!
-   TBranch        *b_genTDLPt_singleLepCalc;   //!
-   TBranch        *b_met_phi_singleLepCalc;   //!
-   TBranch        *b_met_singleLepCalc;   //!
-   TBranch        *b_metnohf_phi_singleLepCalc;   //!
-   TBranch        *b_metnohf_singleLepCalc;   //!
+   TBranch        *b_AK4HT_jerdn_MultiLepCalc;   //!
+   TBranch        *b_AK4HT_jerup_MultiLepCalc;   //!
+   TBranch        *b_AK4HT_jesdn_MultiLepCalc;   //!
+   TBranch        *b_AK4HT_jesup_MultiLepCalc;   //!
+   TBranch        *b_AK4HT_MultiLepCalc;   //!
+   TBranch        *b_HTfromHEPUEP_MultiLepCalc;   //!
+   TBranch        *b_MCWeight_MultiLepCalc;   //!
+   TBranch        *b_corr_met_jerdn_phi_MultiLepCalc;   //!
+   TBranch        *b_corr_met_jerdn_MultiLepCalc;   //!
+   TBranch        *b_corr_met_jerup_phi_MultiLepCalc;   //!
+   TBranch        *b_corr_met_jerup_MultiLepCalc;   //!
+   TBranch        *b_corr_met_jesdn_phi_MultiLepCalc;   //!
+   TBranch        *b_corr_met_jesdn_MultiLepCalc;   //!
+   TBranch        *b_corr_met_jesup_phi_MultiLepCalc;   //!
+   TBranch        *b_corr_met_jesup_MultiLepCalc;   //!
+   TBranch        *b_corr_met_phi_MultiLepCalc;   //!
+   TBranch        *b_corr_met_MultiLepCalc;   //!
+   TBranch        *b_corr_metnohf_phi_MultiLepCalc;   //!
+   TBranch        *b_corr_metnohf_MultiLepCalc;   //!
+   TBranch        *b_genTDLEnergy_MultiLepCalc;   //!
+   TBranch        *b_genTDLEta_MultiLepCalc;   //!
+   TBranch        *b_genTDLPhi_MultiLepCalc;   //!
+   TBranch        *b_genTDLPt_MultiLepCalc;   //!
+   TBranch        *b_met_phi_MultiLepCalc;   //!
+   TBranch        *b_met_MultiLepCalc;   //!
+   TBranch        *b_metnohf_phi_MultiLepCalc;   //!
+   TBranch        *b_metnohf_MultiLepCalc;   //!
    TBranch        *b_theJetHT_JetSubCalc;   //!
    TBranch        *b_theJetLeadPt_JetSubCalc;   //!
    TBranch        *b_theJetSubLeadPt_JetSubCalc;   //!
    TBranch        *b_ttbarMass_TTbarMassCalc;   //!
-   TBranch        *b_AK4JetBTag_bSFdn_singleLepCalc;   //!
-   TBranch        *b_AK4JetBTag_bSFup_singleLepCalc;   //!
-   TBranch        *b_AK4JetBTag_lSFdn_singleLepCalc;   //!
-   TBranch        *b_AK4JetBTag_lSFup_singleLepCalc;   //!
-   TBranch        *b_AK4JetBTag_singleLepCalc;   //!
-   TBranch        *b_AK4JetFlav_singleLepCalc;   //!
+   TBranch        *b_AK4JetBTag_bSFdn_MultiLepCalc;   //!
+   TBranch        *b_AK4JetBTag_bSFup_MultiLepCalc;   //!
+   TBranch        *b_AK4JetBTag_lSFdn_MultiLepCalc;   //!
+   TBranch        *b_AK4JetBTag_lSFup_MultiLepCalc;   //!
+   TBranch        *b_AK4JetBTag_MultiLepCalc;   //!
+   TBranch        *b_AK4JetFlav_MultiLepCalc;   //!
    TBranch        *b_HadronicVHtID_JetSubCalc;   //!
    TBranch        *b_HadronicVHtStatus_JetSubCalc;   //!
    TBranch        *b_HdecayID_TpTpCalc;   //!
    TBranch        *b_HdecayIndex_TpTpCalc;   //!
-   TBranch        *b_LHEweightids_singleLepCalc;   //!
+   TBranch        *b_LHEweightids_MultiLepCalc;   //!
    TBranch        *b_LeptonID_TpTpCalc;   //!
    TBranch        *b_LeptonParentID_TpTpCalc;   //!
    TBranch        *b_WdecayID_TpTpCalc;   //!
@@ -783,60 +783,60 @@ public :
    TBranch        *b_decorr_largest_DeepAK8Calc;   //!
    TBranch        *b_dnn_largest_BestCalc;   //!
    TBranch        *b_dnn_largest_DeepAK8Calc;   //!
-   TBranch        *b_elChargeConsistent_singleLepCalc;   //!
-   TBranch        *b_elCharge_singleLepCalc;   //!
-   TBranch        *b_elCtfCharge_singleLepCalc;   //!
-   TBranch        *b_elGsfCharge_singleLepCalc;   //!
-   TBranch        *b_elIsEBEE_singleLepCalc;   //!
-   TBranch        *b_elIsMVALooseIso_singleLepCalc;   //!
-   TBranch        *b_elIsMVALoose_singleLepCalc;   //!
-   TBranch        *b_elIsMVATightIso_singleLepCalc;   //!
-   TBranch        *b_elIsMVATight_singleLepCalc;   //!
-   TBranch        *b_elMHits_singleLepCalc;   //!
-   TBranch        *b_elMatched_singleLepCalc;   //!
-   TBranch        *b_elMother_id_singleLepCalc;   //!
-   TBranch        *b_elMother_status_singleLepCalc;   //!
-   TBranch        *b_elNotConversion_singleLepCalc;   //!
-   TBranch        *b_elNumberOfMothers_singleLepCalc;   //!
-   TBranch        *b_elPdgId_singleLepCalc;   //!
-   TBranch        *b_elScPixCharge_singleLepCalc;   //!
-   TBranch        *b_elStatus_singleLepCalc;   //!
-   TBranch        *b_elVtxFitConv_singleLepCalc;   //!
-   TBranch        *b_electron_1_hltmatched_singleLepCalc;   //!
-   TBranch        *b_genBSLID_singleLepCalc;   //!
-   TBranch        *b_genID_singleLepCalc;   //!
-   TBranch        *b_genIndex_singleLepCalc;   //!
-   TBranch        *b_genMotherID_singleLepCalc;   //!
-   TBranch        *b_genMotherIndex_singleLepCalc;   //!
-   TBranch        *b_genStatus_singleLepCalc;   //!
+   TBranch        *b_elChargeConsistent_MultiLepCalc;   //!
+   TBranch        *b_elCharge_MultiLepCalc;   //!
+   TBranch        *b_elCtfCharge_MultiLepCalc;   //!
+   TBranch        *b_elGsfCharge_MultiLepCalc;   //!
+   TBranch        *b_elIsEBEE_MultiLepCalc;   //!
+   TBranch        *b_elIsMVALooseIso_MultiLepCalc;   //!
+   TBranch        *b_elIsMVALoose_MultiLepCalc;   //!
+   TBranch        *b_elIsMVATightIso_MultiLepCalc;   //!
+   TBranch        *b_elIsMVATight_MultiLepCalc;   //!
+   TBranch        *b_elMHits_MultiLepCalc;   //!
+   TBranch        *b_elMatched_MultiLepCalc;   //!
+   TBranch        *b_elMother_id_MultiLepCalc;   //!
+   TBranch        *b_elMother_status_MultiLepCalc;   //!
+   TBranch        *b_elNotConversion_MultiLepCalc;   //!
+   TBranch        *b_elNumberOfMothers_MultiLepCalc;   //!
+   TBranch        *b_elPdgId_MultiLepCalc;   //!
+   TBranch        *b_elScPixCharge_MultiLepCalc;   //!
+   TBranch        *b_elStatus_MultiLepCalc;   //!
+   TBranch        *b_elVtxFitConv_MultiLepCalc;   //!
+   TBranch        *b_electron_1_hltmatched_MultiLepCalc;   //!
+   TBranch        *b_genBSLID_MultiLepCalc;   //!
+   TBranch        *b_genID_MultiLepCalc;   //!
+   TBranch        *b_genIndex_MultiLepCalc;   //!
+   TBranch        *b_genMotherID_MultiLepCalc;   //!
+   TBranch        *b_genMotherIndex_MultiLepCalc;   //!
+   TBranch        *b_genStatus_MultiLepCalc;   //!
    TBranch        *b_genTtbarIdCategory_TTbarMassCalc;
    TBranch        *b_maxProb_JetSubCalc;   //!
-   TBranch        *b_muCharge_singleLepCalc;   //!
-   TBranch        *b_muGlobal_singleLepCalc;   //!
-   TBranch        *b_muIsGlobalHighPt_singleLepCalc;   //!
-   TBranch        *b_muIsLoose_singleLepCalc;   //!
-   TBranch        *b_muIsMediumPrompt_singleLepCalc;   //!
-   TBranch        *b_muIsMedium_singleLepCalc;   //!
-   TBranch        *b_muIsMiniIsoLoose_singleLepCalc;   //!
-   TBranch        *b_muIsMiniIsoMedium_singleLepCalc;   //!
-   TBranch        *b_muIsMiniIsoTight_singleLepCalc;   //!
-   TBranch        *b_muIsMiniIsoVeryTight_singleLepCalc;   //!
-   TBranch        *b_muIsMvaLoose_singleLepCalc;   //!
-   TBranch        *b_muIsMvaMedium_singleLepCalc;   //!
-   TBranch        *b_muIsMvaTight_singleLepCalc;   //!
-   TBranch        *b_muIsTight_singleLepCalc;   //!
-   TBranch        *b_muIsTrkHighPt_singleLepCalc;   //!
-   TBranch        *b_muMatched_singleLepCalc;   //!
-   TBranch        *b_muMother_id_singleLepCalc;   //!
-   TBranch        *b_muMother_status_singleLepCalc;   //!
-   TBranch        *b_muNMatchedStations_singleLepCalc;   //!
-   TBranch        *b_muNTrackerLayers_singleLepCalc;   //!
-   TBranch        *b_muNValMuHits_singleLepCalc;   //!
-   TBranch        *b_muNValPixelHits_singleLepCalc;   //!
-   TBranch        *b_muNumberOfMothers_singleLepCalc;   //!
-   TBranch        *b_muPdgId_singleLepCalc;   //!
-   TBranch        *b_muStatus_singleLepCalc;   //!
-   TBranch        *b_muon_1_hltmatched_singleLepCalc;   //!
+   TBranch        *b_muCharge_MultiLepCalc;   //!
+   TBranch        *b_muGlobal_MultiLepCalc;   //!
+   TBranch        *b_muIsGlobalHighPt_MultiLepCalc;   //!
+   TBranch        *b_muIsLoose_MultiLepCalc;   //!
+   TBranch        *b_muIsMediumPrompt_MultiLepCalc;   //!
+   TBranch        *b_muIsMedium_MultiLepCalc;   //!
+   TBranch        *b_muIsMiniIsoLoose_MultiLepCalc;   //!
+   TBranch        *b_muIsMiniIsoMedium_MultiLepCalc;   //!
+   TBranch        *b_muIsMiniIsoTight_MultiLepCalc;   //!
+   TBranch        *b_muIsMiniIsoVeryTight_MultiLepCalc;   //!
+   TBranch        *b_muIsMvaLoose_MultiLepCalc;   //!
+   TBranch        *b_muIsMvaMedium_MultiLepCalc;   //!
+   TBranch        *b_muIsMvaTight_MultiLepCalc;   //!
+   TBranch        *b_muIsTight_MultiLepCalc;   //!
+   TBranch        *b_muIsTrkHighPt_MultiLepCalc;   //!
+   TBranch        *b_muMatched_MultiLepCalc;   //!
+   TBranch        *b_muMother_id_MultiLepCalc;   //!
+   TBranch        *b_muMother_status_MultiLepCalc;   //!
+   TBranch        *b_muNMatchedStations_MultiLepCalc;   //!
+   TBranch        *b_muNTrackerLayers_MultiLepCalc;   //!
+   TBranch        *b_muNValMuHits_MultiLepCalc;   //!
+   TBranch        *b_muNValPixelHits_MultiLepCalc;   //!
+   TBranch        *b_muNumberOfMothers_MultiLepCalc;   //!
+   TBranch        *b_muPdgId_MultiLepCalc;   //!
+   TBranch        *b_muStatus_MultiLepCalc;   //!
+   TBranch        *b_muon_1_hltmatched_MultiLepCalc;   //!
    TBranch        *b_quarkID_TpTpCalc;   //!
    TBranch        *b_tPrimeID_TpTpCalc;   //!
    TBranch        *b_tPrimeNDaughters_TpTpCalc;   //!
@@ -864,45 +864,45 @@ public :
    TBranch        *b_topID_TTbarMassCalc;   //!
    TBranch        *b_topWID_TTbarMassCalc;   //!
    TBranch        *b_topbID_TTbarMassCalc;   //!
-   TBranch        *b_viSelMCTriggersEl_singleLepCalc;   //!
-   TBranch        *b_viSelMCTriggersMu_singleLepCalc;   //!
-   TBranch        *b_viSelTriggersEl_singleLepCalc;   //!
-   TBranch        *b_viSelTriggersMu_singleLepCalc;   //!
-   TBranch        *b_AK4JetBDeepCSVb_singleLepCalc;   //!
-   TBranch        *b_AK4JetBDeepCSVbb_singleLepCalc;   //!
-   TBranch        *b_AK4JetBDeepCSVc_singleLepCalc;   //!
-   TBranch        *b_AK4JetBDeepCSVudsg_singleLepCalc;   //!
-   TBranch        *b_AK4JetBDisc_singleLepCalc;   //!
-   TBranch        *b_AK4JetEnergy_jerdn_singleLepCalc;   //!
-   TBranch        *b_AK4JetEnergy_jerup_singleLepCalc;   //!
-   TBranch        *b_AK4JetEnergy_jesdn_singleLepCalc;   //!
-   TBranch        *b_AK4JetEnergy_jesup_singleLepCalc;   //!
-   TBranch        *b_AK4JetEnergy_singleLepCalc;   //!
-   TBranch        *b_AK4JetEta_singleLepCalc;   //!
-   TBranch        *b_AK4JetPhi_singleLepCalc;   //!
-   TBranch        *b_AK4JetPt_jerdn_singleLepCalc;   //!
-   TBranch        *b_AK4JetPt_jerup_singleLepCalc;   //!
-   TBranch        *b_AK4JetPt_jesdn_singleLepCalc;   //!
-   TBranch        *b_AK4JetPt_jesup_singleLepCalc;   //!
-   TBranch        *b_AK4JetPt_singleLepCalc;   //!
+   TBranch        *b_viSelMCTriggersEl_MultiLepCalc;   //!
+   TBranch        *b_viSelMCTriggersMu_MultiLepCalc;   //!
+   TBranch        *b_viSelTriggersEl_MultiLepCalc;   //!
+   TBranch        *b_viSelTriggersMu_MultiLepCalc;   //!
+   TBranch        *b_AK4JetBDeepCSVb_MultiLepCalc;   //!
+   TBranch        *b_AK4JetBDeepCSVbb_MultiLepCalc;   //!
+   TBranch        *b_AK4JetBDeepCSVc_MultiLepCalc;   //!
+   TBranch        *b_AK4JetBDeepCSVudsg_MultiLepCalc;   //!
+   TBranch        *b_AK4JetBDisc_MultiLepCalc;   //!
+   TBranch        *b_AK4JetEnergy_jerdn_MultiLepCalc;   //!
+   TBranch        *b_AK4JetEnergy_jerup_MultiLepCalc;   //!
+   TBranch        *b_AK4JetEnergy_jesdn_MultiLepCalc;   //!
+   TBranch        *b_AK4JetEnergy_jesup_MultiLepCalc;   //!
+   TBranch        *b_AK4JetEnergy_MultiLepCalc;   //!
+   TBranch        *b_AK4JetEta_MultiLepCalc;   //!
+   TBranch        *b_AK4JetPhi_MultiLepCalc;   //!
+   TBranch        *b_AK4JetPt_jerdn_MultiLepCalc;   //!
+   TBranch        *b_AK4JetPt_jerup_MultiLepCalc;   //!
+   TBranch        *b_AK4JetPt_jesdn_MultiLepCalc;   //!
+   TBranch        *b_AK4JetPt_jesup_MultiLepCalc;   //!
+   TBranch        *b_AK4JetPt_MultiLepCalc;   //!
    TBranch        *b_AK8JetCSV_BestCalc;   //!
-   TBranch        *b_AK8JetCSV_singleLepCalc;   //!
+   TBranch        *b_AK8JetCSV_MultiLepCalc;   //!
    TBranch        *b_AK8JetEnergy_BestCalc;   //!
-   TBranch        *b_AK8JetEnergy_jerdn_singleLepCalc;   //!
-   TBranch        *b_AK8JetEnergy_jerup_singleLepCalc;   //!
-   TBranch        *b_AK8JetEnergy_jesdn_singleLepCalc;   //!
-   TBranch        *b_AK8JetEnergy_jesup_singleLepCalc;   //!
-   TBranch        *b_AK8JetEnergy_singleLepCalc;   //!
+   TBranch        *b_AK8JetEnergy_jerdn_MultiLepCalc;   //!
+   TBranch        *b_AK8JetEnergy_jerup_MultiLepCalc;   //!
+   TBranch        *b_AK8JetEnergy_jesdn_MultiLepCalc;   //!
+   TBranch        *b_AK8JetEnergy_jesup_MultiLepCalc;   //!
+   TBranch        *b_AK8JetEnergy_MultiLepCalc;   //!
    TBranch        *b_AK8JetEta_BestCalc;   //!
-   TBranch        *b_AK8JetEta_singleLepCalc;   //!
+   TBranch        *b_AK8JetEta_MultiLepCalc;   //!
    TBranch        *b_AK8JetPhi_BestCalc;   //!
-   TBranch        *b_AK8JetPhi_singleLepCalc;   //!
+   TBranch        *b_AK8JetPhi_MultiLepCalc;   //!
    TBranch        *b_AK8JetPt_BestCalc;   //!
-   TBranch        *b_AK8JetPt_jerdn_singleLepCalc;   //!
-   TBranch        *b_AK8JetPt_jerup_singleLepCalc;   //!
-   TBranch        *b_AK8JetPt_jesdn_singleLepCalc;   //!
-   TBranch        *b_AK8JetPt_jesup_singleLepCalc;   //!
-   TBranch        *b_AK8JetPt_singleLepCalc;   //!
+   TBranch        *b_AK8JetPt_jerdn_MultiLepCalc;   //!
+   TBranch        *b_AK8JetPt_jerup_MultiLepCalc;   //!
+   TBranch        *b_AK8JetPt_jesdn_MultiLepCalc;   //!
+   TBranch        *b_AK8JetPt_jesup_MultiLepCalc;   //!
+   TBranch        *b_AK8JetPt_MultiLepCalc;   //!
    TBranch        *b_FWmoment1H_BestCalc;   //!
    TBranch        *b_FWmoment1W_BestCalc;   //!
    TBranch        *b_FWmoment1Z_BestCalc;   //!
@@ -939,7 +939,7 @@ public :
    TBranch        *b_HdecayEta_TpTpCalc;   //!
    TBranch        *b_HdecayPhi_TpTpCalc;   //!
    TBranch        *b_HdecayPt_TpTpCalc;   //!
-   TBranch        *b_LHEweights_singleLepCalc;   //!
+   TBranch        *b_LHEweights_MultiLepCalc;   //!
    TBranch        *b_LeptonEnergy_TpTpCalc;   //!
    TBranch        *b_LeptonEta_TpTpCalc;   //!
    TBranch        *b_LeptonPhi_TpTpCalc;   //!
@@ -997,69 +997,69 @@ public :
    TBranch        *b_dnn_W_DeepAK8Calc;   //!
    TBranch        *b_dnn_Z_BestCalc;   //!
    TBranch        *b_dnn_Z_DeepAK8Calc;   //!
-   TBranch        *b_elAEff_singleLepCalc;   //!
-   TBranch        *b_elChIso_singleLepCalc;   //!
-   TBranch        *b_elD0_singleLepCalc;   //!
-   TBranch        *b_elDEtaSCTkAtVtx_singleLepCalc;   //!
-   TBranch        *b_elDPhiSCTkAtVtx_singleLepCalc;   //!
-   TBranch        *b_elDR03TkSumPt_singleLepCalc;   //!
-   TBranch        *b_elDZ_singleLepCalc;   //!
-   TBranch        *b_elDeta_singleLepCalc;   //!
-   TBranch        *b_elDphi_singleLepCalc;   //!
-   TBranch        *b_elDxy_singleLepCalc;   //!
-   TBranch        *b_elEcalPFClusterIso_singleLepCalc;   //!
-   TBranch        *b_elEnergy_singleLepCalc;   //!
-   TBranch        *b_elEtaVtx_singleLepCalc;   //!
-   TBranch        *b_elEta_singleLepCalc;   //!
-   TBranch        *b_elGen_Reco_dr_singleLepCalc;   //!
-   TBranch        *b_elHcalPFClusterIso_singleLepCalc;   //!
-   TBranch        *b_elHoE_singleLepCalc;   //!
-   TBranch        *b_elIsLooseBarrel_singleLepCalc;   //!
-   TBranch        *b_elIsLooseEndCap_singleLepCalc;   //!
-   TBranch        *b_elIsMediumBarrel_singleLepCalc;   //!
-   TBranch        *b_elIsMediumEndCap_singleLepCalc;   //!
-   TBranch        *b_elIsTightBarrel_singleLepCalc;   //!
-   TBranch        *b_elIsTightEndCap_singleLepCalc;   //!
-   TBranch        *b_elIsVetoBarrel_singleLepCalc;   //!
-   TBranch        *b_elIsVetoEndCap_singleLepCalc;   //!
-   TBranch        *b_elMVAValue_iso_singleLepCalc;   //!
-   TBranch        *b_elMVAValue_singleLepCalc;   //!
-   TBranch        *b_elMatchedEnergy_singleLepCalc;   //!
-   TBranch        *b_elMatchedEta_singleLepCalc;   //!
-   TBranch        *b_elMatchedPhi_singleLepCalc;   //!
-   TBranch        *b_elMatchedPt_singleLepCalc;   //!
-   TBranch        *b_elMiniIso_singleLepCalc;   //!
-   TBranch        *b_elMother_energy_singleLepCalc;   //!
-   TBranch        *b_elMother_eta_singleLepCalc;   //!
-   TBranch        *b_elMother_phi_singleLepCalc;   //!
-   TBranch        *b_elMother_pt_singleLepCalc;   //!
-   TBranch        *b_elNhIso_singleLepCalc;   //!
-   TBranch        *b_elOoemoop_singleLepCalc;   //!
-   TBranch        *b_elPFEta_singleLepCalc;   //!
-   TBranch        *b_elPFPhi_singleLepCalc;   //!
-   TBranch        *b_elPhIso_singleLepCalc;   //!
-   TBranch        *b_elPhiVtx_singleLepCalc;   //!
-   TBranch        *b_elPhi_singleLepCalc;   //!
-   TBranch        *b_elPt_singleLepCalc;   //!
-   TBranch        *b_elRelIso_singleLepCalc;   //!
-   TBranch        *b_elRhoIso_singleLepCalc;   //!
-   TBranch        *b_elSCE_singleLepCalc;   //!
-   TBranch        *b_elSihih_singleLepCalc;   //!
+   TBranch        *b_elAEff_MultiLepCalc;   //!
+   TBranch        *b_elChIso_MultiLepCalc;   //!
+   TBranch        *b_elD0_MultiLepCalc;   //!
+   TBranch        *b_elDEtaSCTkAtVtx_MultiLepCalc;   //!
+   TBranch        *b_elDPhiSCTkAtVtx_MultiLepCalc;   //!
+   TBranch        *b_elDR03TkSumPt_MultiLepCalc;   //!
+   TBranch        *b_elDZ_MultiLepCalc;   //!
+   TBranch        *b_elDeta_MultiLepCalc;   //!
+   TBranch        *b_elDphi_MultiLepCalc;   //!
+   TBranch        *b_elDxy_MultiLepCalc;   //!
+   TBranch        *b_elEcalPFClusterIso_MultiLepCalc;   //!
+   TBranch        *b_elEnergy_MultiLepCalc;   //!
+   TBranch        *b_elEtaVtx_MultiLepCalc;   //!
+   TBranch        *b_elEta_MultiLepCalc;   //!
+   TBranch        *b_elGen_Reco_dr_MultiLepCalc;   //!
+   TBranch        *b_elHcalPFClusterIso_MultiLepCalc;   //!
+   TBranch        *b_elHoE_MultiLepCalc;   //!
+   TBranch        *b_elIsLooseBarrel_MultiLepCalc;   //!
+   TBranch        *b_elIsLooseEndCap_MultiLepCalc;   //!
+   TBranch        *b_elIsMediumBarrel_MultiLepCalc;   //!
+   TBranch        *b_elIsMediumEndCap_MultiLepCalc;   //!
+   TBranch        *b_elIsTightBarrel_MultiLepCalc;   //!
+   TBranch        *b_elIsTightEndCap_MultiLepCalc;   //!
+   TBranch        *b_elIsVetoBarrel_MultiLepCalc;   //!
+   TBranch        *b_elIsVetoEndCap_MultiLepCalc;   //!
+   TBranch        *b_elMVAValue_iso_MultiLepCalc;   //!
+//   TBranch        *b_elMVAValue_MultiLepCalc;   //!
+   TBranch        *b_elMatchedEnergy_MultiLepCalc;   //!
+   TBranch        *b_elMatchedEta_MultiLepCalc;   //!
+   TBranch        *b_elMatchedPhi_MultiLepCalc;   //!
+   TBranch        *b_elMatchedPt_MultiLepCalc;   //!
+   TBranch        *b_elMiniIso_MultiLepCalc;   //!
+   TBranch        *b_elMother_energy_MultiLepCalc;   //!
+   TBranch        *b_elMother_eta_MultiLepCalc;   //!
+   TBranch        *b_elMother_phi_MultiLepCalc;   //!
+   TBranch        *b_elMother_pt_MultiLepCalc;   //!
+   TBranch        *b_elNhIso_MultiLepCalc;   //!
+   TBranch        *b_elOoemoop_MultiLepCalc;   //!
+   TBranch        *b_elPFEta_MultiLepCalc;   //!
+   TBranch        *b_elPFPhi_MultiLepCalc;   //!
+   TBranch        *b_elPhIso_MultiLepCalc;   //!
+   TBranch        *b_elPhiVtx_MultiLepCalc;   //!
+   TBranch        *b_elPhi_MultiLepCalc;   //!
+   TBranch        *b_elPt_MultiLepCalc;   //!
+   TBranch        *b_elRelIso_MultiLepCalc;   //!
+   TBranch        *b_elRhoIso_MultiLepCalc;   //!
+   TBranch        *b_elSCE_MultiLepCalc;   //!
+   TBranch        *b_elSihih_MultiLepCalc;   //!
    TBranch        *b_et_BestCalc;   //!
    TBranch        *b_eta_BestCalc;   //!
-   TBranch        *b_evtWeightsMC_singleLepCalc;   //!
-   TBranch        *b_genBSLEnergy_singleLepCalc;   //!
-   TBranch        *b_genBSLEta_singleLepCalc;   //!
-   TBranch        *b_genBSLPhi_singleLepCalc;   //!
-   TBranch        *b_genBSLPt_singleLepCalc;   //!
-   TBranch        *b_genEnergy_singleLepCalc;   //!
-   TBranch        *b_genEta_singleLepCalc;   //!
-   TBranch        *b_genJetEnergy_singleLepCalc;   //!
-   TBranch        *b_genJetEta_singleLepCalc;   //!
-   TBranch        *b_genJetPhi_singleLepCalc;   //!
-   TBranch        *b_genJetPt_singleLepCalc;   //!
-   TBranch        *b_genPhi_singleLepCalc;   //!
-   TBranch        *b_genPt_singleLepCalc;   //!
+   TBranch        *b_evtWeightsMC_MultiLepCalc;   //!
+   TBranch        *b_genBSLEnergy_MultiLepCalc;   //!
+   TBranch        *b_genBSLEta_MultiLepCalc;   //!
+   TBranch        *b_genBSLPhi_MultiLepCalc;   //!
+   TBranch        *b_genBSLPt_MultiLepCalc;   //!
+   TBranch        *b_genEnergy_MultiLepCalc;   //!
+   TBranch        *b_genEta_MultiLepCalc;   //!
+   TBranch        *b_genJetEnergy_MultiLepCalc;   //!
+   TBranch        *b_genJetEta_MultiLepCalc;   //!
+   TBranch        *b_genJetPhi_MultiLepCalc;   //!
+   TBranch        *b_genJetPt_MultiLepCalc;   //!
+   TBranch        *b_genPhi_MultiLepCalc;   //!
+   TBranch        *b_genPt_MultiLepCalc;   //!
    TBranch        *b_isotropyH_BestCalc;   //!
    TBranch        *b_isotropyW_BestCalc;   //!
    TBranch        *b_isotropyZ_BestCalc;   //!
@@ -1085,32 +1085,32 @@ public :
    TBranch        *b_m23_jet_BestCalc;   //!
    TBranch        *b_m23top_BestCalc;   //!
    TBranch        *b_mass_BestCalc;   //!
-   TBranch        *b_muChIso_singleLepCalc;   //!
-   TBranch        *b_muChi2_singleLepCalc;   //!
-   TBranch        *b_muDxy_singleLepCalc;   //!
-   TBranch        *b_muDz_singleLepCalc;   //!
-   TBranch        *b_muEnergy_singleLepCalc;   //!
-   TBranch        *b_muEta_singleLepCalc;   //!
-   TBranch        *b_muGIso_singleLepCalc;   //!
-   TBranch        *b_muGen_Reco_dr_singleLepCalc;   //!
-   TBranch        *b_muInnerEta_singleLepCalc;   //!
-   TBranch        *b_muInnerPhi_singleLepCalc;   //!
-   TBranch        *b_muInnerPt_singleLepCalc;   //!
-   TBranch        *b_muMatchedEnergy_singleLepCalc;   //!
-   TBranch        *b_muMatchedEta_singleLepCalc;   //!
-   TBranch        *b_muMatchedPhi_singleLepCalc;   //!
-   TBranch        *b_muMatchedPt_singleLepCalc;   //!
-   TBranch        *b_muMiniIsoDB_singleLepCalc;   //!
-   TBranch        *b_muMiniIso_singleLepCalc;   //!
-   TBranch        *b_muMother_energy_singleLepCalc;   //!
-   TBranch        *b_muMother_eta_singleLepCalc;   //!
-   TBranch        *b_muMother_phi_singleLepCalc;   //!
-   TBranch        *b_muMother_pt_singleLepCalc;   //!
-   TBranch        *b_muNhIso_singleLepCalc;   //!
-   TBranch        *b_muPhi_singleLepCalc;   //!
-   TBranch        *b_muPt_singleLepCalc;   //!
-   TBranch        *b_muPuIso_singleLepCalc;   //!
-   TBranch        *b_muRelIso_singleLepCalc;   //!
+   TBranch        *b_muChIso_MultiLepCalc;   //!
+   TBranch        *b_muChi2_MultiLepCalc;   //!
+   TBranch        *b_muDxy_MultiLepCalc;   //!
+   TBranch        *b_muDz_MultiLepCalc;   //!
+   TBranch        *b_muEnergy_MultiLepCalc;   //!
+   TBranch        *b_muEta_MultiLepCalc;   //!
+   TBranch        *b_muGIso_MultiLepCalc;   //!
+   TBranch        *b_muGen_Reco_dr_MultiLepCalc;   //!
+   TBranch        *b_muInnerEta_MultiLepCalc;   //!
+   TBranch        *b_muInnerPhi_MultiLepCalc;   //!
+   TBranch        *b_muInnerPt_MultiLepCalc;   //!
+   TBranch        *b_muMatchedEnergy_MultiLepCalc;   //!
+   TBranch        *b_muMatchedEta_MultiLepCalc;   //!
+   TBranch        *b_muMatchedPhi_MultiLepCalc;   //!
+   TBranch        *b_muMatchedPt_MultiLepCalc;   //!
+   TBranch        *b_muMiniIsoDB_MultiLepCalc;   //!
+   TBranch        *b_muMiniIso_MultiLepCalc;   //!
+   TBranch        *b_muMother_energy_MultiLepCalc;   //!
+   TBranch        *b_muMother_eta_MultiLepCalc;   //!
+   TBranch        *b_muMother_phi_MultiLepCalc;   //!
+   TBranch        *b_muMother_pt_MultiLepCalc;   //!
+   TBranch        *b_muNhIso_MultiLepCalc;   //!
+   TBranch        *b_muPhi_MultiLepCalc;   //!
+   TBranch        *b_muPt_MultiLepCalc;   //!
+   TBranch        *b_muPuIso_MultiLepCalc;   //!
+   TBranch        *b_muRelIso_MultiLepCalc;   //!
    TBranch        *b_pzOverp_H_BestCalc;   //!
    TBranch        *b_pzOverp_W_BestCalc;   //!
    TBranch        *b_pzOverp_Z_BestCalc;   //!
@@ -1202,12 +1202,12 @@ public :
    TBranch        *b_topbEta_TTbarMassCalc;   //!
    TBranch        *b_topbPhi_TTbarMassCalc;   //!
    TBranch        *b_topbPt_TTbarMassCalc;   //!
-   TBranch        *b_electron_hltfilters_singleLepCalc;   //!
-   TBranch        *b_muon_hltfilters_singleLepCalc;   //!
-   TBranch        *b_vsSelMCTriggersEl_singleLepCalc;   //!
-   TBranch        *b_vsSelMCTriggersMu_singleLepCalc;   //!
-   TBranch        *b_vsSelTriggersEl_singleLepCalc;   //!
-   TBranch        *b_vsSelTriggersMu_singleLepCalc;   //!
+   TBranch        *b_electron_hltfilters_MultiLepCalc;   //!
+   TBranch        *b_muon_hltfilters_MultiLepCalc;   //!
+   TBranch        *b_vsSelMCTriggersEl_MultiLepCalc;   //!
+   TBranch        *b_vsSelMCTriggersMu_MultiLepCalc;   //!
+   TBranch        *b_vsSelTriggersEl_MultiLepCalc;   //!
+   TBranch        *b_vsSelTriggersMu_MultiLepCalc;   //!
  
    step1(TString inputFileName, TString outputFileName);
    virtual ~step1();
@@ -1215,10 +1215,11 @@ public :
    virtual Int_t    GetEntry(Long64_t entry);
    virtual Long64_t LoadTree(Long64_t entry);
    virtual void     Init(TTree *tree);
-   virtual void     Loop();
+   virtual void     Loop(TString inTreeName, TString outTreeName);
    virtual Bool_t   Notify();
    virtual void     Show(Long64_t entry = -1);
    bool             applySF(bool& isTagged, float tag_SF, float tag_eff);
+   virtual void     saveHistograms();
 };
 
 #endif
@@ -1294,12 +1295,12 @@ step1::step1(TString inputFileName, TString outputFileName) : inputTree(0), inpu
 
   std::cout<<"Opening file: "<<inputFileName<<std::endl;
   inputFile=TFile::Open(inputFileName);
-  inputTree=(TTree*)inputFile->Get("ljmet");
-  if(inputTree->GetEntries()==0) std::cout<<"WARNING! Found 0 events in the tree!!!!"<<std::endl;;
+//  inputTree=(TTree*)inputFile->Get("ljmet/ljmet");
+//  if(inputTree->GetEntries()==0) std::cout<<"WARNING! Found 0 events in the tree!!!!"<<std::endl;;
   
   outputFile=new TFile(outputFileName,"RECREATE");   
   
-  Init(inputTree);
+  // Init(inputTree);
 }
 
 step1::~step1()
@@ -1338,17 +1339,17 @@ void step1::Init(TTree *tree)
    // (once per file to be processed).
 
    // Set object pointer
-   AK4JetBTag_bSFdn_singleLepCalc = 0;
-   AK4JetBTag_bSFup_singleLepCalc = 0;
-   AK4JetBTag_lSFdn_singleLepCalc = 0;
-   AK4JetBTag_lSFup_singleLepCalc = 0;
-   AK4JetBTag_singleLepCalc = 0;
-   AK4JetFlav_singleLepCalc = 0;
+   AK4JetBTag_bSFdn_MultiLepCalc = 0;
+   AK4JetBTag_bSFup_MultiLepCalc = 0;
+   AK4JetBTag_lSFdn_MultiLepCalc = 0;
+   AK4JetBTag_lSFup_MultiLepCalc = 0;
+   AK4JetBTag_MultiLepCalc = 0;
+   AK4JetFlav_MultiLepCalc = 0;
    HadronicVHtID_JetSubCalc = 0;
    HadronicVHtStatus_JetSubCalc = 0;
    HdecayID_TpTpCalc = 0;
    HdecayIndex_TpTpCalc = 0;
-   LHEweightids_singleLepCalc = 0;
+   LHEweightids_MultiLepCalc = 0;
    LeptonID_TpTpCalc = 0;
    LeptonParentID_TpTpCalc = 0;
    WdecayID_TpTpCalc = 0;
@@ -1364,60 +1365,60 @@ void step1::Init(TTree *tree)
    decorr_largest_DeepAK8Calc = 0;
    dnn_largest_BestCalc = 0;
    dnn_largest_DeepAK8Calc = 0;
-   elChargeConsistent_singleLepCalc = 0;
-   elCharge_singleLepCalc = 0;
-   elCtfCharge_singleLepCalc = 0;
-   elGsfCharge_singleLepCalc = 0;
-   elIsEBEE_singleLepCalc = 0;
-   elIsMVALooseIso_singleLepCalc = 0;
-   elIsMVALoose_singleLepCalc = 0;
-   elIsMVATightIso_singleLepCalc = 0;
-   elIsMVATight_singleLepCalc = 0;
-   elMHits_singleLepCalc = 0;
-   elMatched_singleLepCalc = 0;
-   elMother_id_singleLepCalc = 0;
-   elMother_status_singleLepCalc = 0;
-   elNotConversion_singleLepCalc = 0;
-   elNumberOfMothers_singleLepCalc = 0;
-   elPdgId_singleLepCalc = 0;
-   elScPixCharge_singleLepCalc = 0;
-   elStatus_singleLepCalc = 0;
-   elVtxFitConv_singleLepCalc = 0;
-   electron_1_hltmatched_singleLepCalc = 0;
-   genBSLID_singleLepCalc = 0;
-   genID_singleLepCalc = 0;
-   genIndex_singleLepCalc = 0;
-   genMotherID_singleLepCalc = 0;
-   genMotherIndex_singleLepCalc = 0;
-   genStatus_singleLepCalc = 0;
+   elChargeConsistent_MultiLepCalc = 0;
+   elCharge_MultiLepCalc = 0;
+   elCtfCharge_MultiLepCalc = 0;
+   elGsfCharge_MultiLepCalc = 0;
+   elIsEBEE_MultiLepCalc = 0;
+   elIsMVALooseIso_MultiLepCalc = 0;
+   elIsMVALoose_MultiLepCalc = 0;
+   elIsMVATightIso_MultiLepCalc = 0;
+   elIsMVATight_MultiLepCalc = 0;
+   elMHits_MultiLepCalc = 0;
+   elMatched_MultiLepCalc = 0;
+   elMother_id_MultiLepCalc = 0;
+   elMother_status_MultiLepCalc = 0;
+   elNotConversion_MultiLepCalc = 0;
+   elNumberOfMothers_MultiLepCalc = 0;
+   elPdgId_MultiLepCalc = 0;
+   elScPixCharge_MultiLepCalc = 0;
+   elStatus_MultiLepCalc = 0;
+   elVtxFitConv_MultiLepCalc = 0;
+   electron_1_hltmatched_MultiLepCalc = 0;
+   genBSLID_MultiLepCalc = 0;
+   genID_MultiLepCalc = 0;
+   genIndex_MultiLepCalc = 0;
+   genMotherID_MultiLepCalc = 0;
+   genMotherIndex_MultiLepCalc = 0;
+   genStatus_MultiLepCalc = 0;
    genTtbarIdCategory_TTbarMassCalc = 0;
    maxProb_JetSubCalc = 0;
-   muCharge_singleLepCalc = 0;
-   muGlobal_singleLepCalc = 0;
-   muIsGlobalHighPt_singleLepCalc = 0;
-   muIsLoose_singleLepCalc = 0;
-   muIsMediumPrompt_singleLepCalc = 0;
-   muIsMedium_singleLepCalc = 0;
-   muIsMiniIsoLoose_singleLepCalc = 0;
-   muIsMiniIsoMedium_singleLepCalc = 0;
-   muIsMiniIsoTight_singleLepCalc = 0;
-   muIsMiniIsoVeryTight_singleLepCalc = 0;
-   muIsMvaLoose_singleLepCalc = 0;
-   muIsMvaMedium_singleLepCalc = 0;
-   muIsMvaTight_singleLepCalc = 0;
-   muIsTight_singleLepCalc = 0;
-   muIsTrkHighPt_singleLepCalc = 0;
-   muMatched_singleLepCalc = 0;
-   muMother_id_singleLepCalc = 0; 
-   muMother_status_singleLepCalc = 0;
-   muNMatchedStations_singleLepCalc = 0;
-   muNTrackerLayers_singleLepCalc = 0;
-   muNValMuHits_singleLepCalc = 0;
-   muNValPixelHits_singleLepCalc = 0;
-   muNumberOfMothers_singleLepCalc = 0;
-   muPdgId_singleLepCalc = 0;
-   muStatus_singleLepCalc = 0;
-   muon_1_hltmatched_singleLepCalc = 0;
+   muCharge_MultiLepCalc = 0;
+   muGlobal_MultiLepCalc = 0;
+   muIsGlobalHighPt_MultiLepCalc = 0;
+   muIsLoose_MultiLepCalc = 0;
+   muIsMediumPrompt_MultiLepCalc = 0;
+   muIsMedium_MultiLepCalc = 0;
+   muIsMiniIsoLoose_MultiLepCalc = 0;
+   muIsMiniIsoMedium_MultiLepCalc = 0;
+   muIsMiniIsoTight_MultiLepCalc = 0;
+   muIsMiniIsoVeryTight_MultiLepCalc = 0;
+   muIsMvaLoose_MultiLepCalc = 0;
+   muIsMvaMedium_MultiLepCalc = 0;
+   muIsMvaTight_MultiLepCalc = 0;
+   muIsTight_MultiLepCalc = 0;
+   muIsTrkHighPt_MultiLepCalc = 0;
+   muMatched_MultiLepCalc = 0;
+   muMother_id_MultiLepCalc = 0; 
+   muMother_status_MultiLepCalc = 0;
+   muNMatchedStations_MultiLepCalc = 0;
+   muNTrackerLayers_MultiLepCalc = 0;
+   muNValMuHits_MultiLepCalc = 0;
+   muNValPixelHits_MultiLepCalc = 0;
+   muNumberOfMothers_MultiLepCalc = 0;
+   muPdgId_MultiLepCalc = 0;
+   muStatus_MultiLepCalc = 0;
+   muon_1_hltmatched_MultiLepCalc = 0;
    quarkID_TpTpCalc = 0;
    tPrimeID_TpTpCalc = 0;
    tPrimeNDaughters_TpTpCalc = 0;
@@ -1445,45 +1446,45 @@ void step1::Init(TTree *tree)
    topID_TTbarMassCalc = 0;
    topWID_TTbarMassCalc = 0;
    topbID_TTbarMassCalc = 0;
-   viSelMCTriggersEl_singleLepCalc = 0;
-   viSelMCTriggersMu_singleLepCalc = 0;
-   viSelTriggersEl_singleLepCalc = 0;
-   viSelTriggersMu_singleLepCalc = 0;
-   AK4JetBDeepCSVb_singleLepCalc = 0;
-   AK4JetBDeepCSVbb_singleLepCalc = 0;
-   AK4JetBDeepCSVc_singleLepCalc = 0;
-   AK4JetBDeepCSVudsg_singleLepCalc = 0;
-   AK4JetBDisc_singleLepCalc = 0;
-   AK4JetEnergy_jerdn_singleLepCalc = 0;
-   AK4JetEnergy_jerup_singleLepCalc = 0;
-   AK4JetEnergy_jesdn_singleLepCalc = 0;
-   AK4JetEnergy_jesup_singleLepCalc = 0;
-   AK4JetEnergy_singleLepCalc = 0;
-   AK4JetEta_singleLepCalc = 0;
-   AK4JetPhi_singleLepCalc = 0;
-   AK4JetPt_jerdn_singleLepCalc = 0;
-   AK4JetPt_jerup_singleLepCalc = 0;
-   AK4JetPt_jesdn_singleLepCalc = 0;
-   AK4JetPt_jesup_singleLepCalc = 0;
-   AK4JetPt_singleLepCalc = 0;
+   viSelMCTriggersEl_MultiLepCalc = 0;
+   viSelMCTriggersMu_MultiLepCalc = 0;
+   viSelTriggersEl_MultiLepCalc = 0;
+   viSelTriggersMu_MultiLepCalc = 0;
+   AK4JetBDeepCSVb_MultiLepCalc = 0;
+   AK4JetBDeepCSVbb_MultiLepCalc = 0;
+   AK4JetBDeepCSVc_MultiLepCalc = 0;
+   AK4JetBDeepCSVudsg_MultiLepCalc = 0;
+   AK4JetBDisc_MultiLepCalc = 0;
+   AK4JetEnergy_jerdn_MultiLepCalc = 0;
+   AK4JetEnergy_jerup_MultiLepCalc = 0;
+   AK4JetEnergy_jesdn_MultiLepCalc = 0;
+   AK4JetEnergy_jesup_MultiLepCalc = 0;
+   AK4JetEnergy_MultiLepCalc = 0;
+   AK4JetEta_MultiLepCalc = 0;
+   AK4JetPhi_MultiLepCalc = 0;
+   AK4JetPt_jerdn_MultiLepCalc = 0;
+   AK4JetPt_jerup_MultiLepCalc = 0;
+   AK4JetPt_jesdn_MultiLepCalc = 0;
+   AK4JetPt_jesup_MultiLepCalc = 0;
+   AK4JetPt_MultiLepCalc = 0;
    AK8JetCSV_BestCalc = 0;
-   AK8JetCSV_singleLepCalc = 0;
+   AK8JetCSV_MultiLepCalc = 0;
    AK8JetEnergy_BestCalc = 0;
-   AK8JetEnergy_jerdn_singleLepCalc = 0;
-   AK8JetEnergy_jerup_singleLepCalc = 0;
-   AK8JetEnergy_jesdn_singleLepCalc = 0;
-   AK8JetEnergy_jesup_singleLepCalc = 0;
-   AK8JetEnergy_singleLepCalc = 0;
+   AK8JetEnergy_jerdn_MultiLepCalc = 0;
+   AK8JetEnergy_jerup_MultiLepCalc = 0;
+   AK8JetEnergy_jesdn_MultiLepCalc = 0;
+   AK8JetEnergy_jesup_MultiLepCalc = 0;
+   AK8JetEnergy_MultiLepCalc = 0;
    AK8JetEta_BestCalc = 0;
-   AK8JetEta_singleLepCalc = 0;
+   AK8JetEta_MultiLepCalc = 0;
    AK8JetPhi_BestCalc = 0;
-   AK8JetPhi_singleLepCalc = 0;
+   AK8JetPhi_MultiLepCalc = 0;
    AK8JetPt_BestCalc = 0;
-   AK8JetPt_jerdn_singleLepCalc = 0;
-   AK8JetPt_jerup_singleLepCalc = 0;
-   AK8JetPt_jesdn_singleLepCalc = 0;
-   AK8JetPt_jesup_singleLepCalc = 0;
-   AK8JetPt_singleLepCalc = 0;
+   AK8JetPt_jerdn_MultiLepCalc = 0;
+   AK8JetPt_jerup_MultiLepCalc = 0;
+   AK8JetPt_jesdn_MultiLepCalc = 0;
+   AK8JetPt_jesup_MultiLepCalc = 0;
+   AK8JetPt_MultiLepCalc = 0;
    FWmoment1H_BestCalc = 0;
    FWmoment1W_BestCalc = 0;
    FWmoment1Z_BestCalc = 0;
@@ -1520,7 +1521,7 @@ void step1::Init(TTree *tree)
    HdecayEta_TpTpCalc = 0;
    HdecayPhi_TpTpCalc = 0;
    HdecayPt_TpTpCalc = 0;
-   LHEweights_singleLepCalc = 0;
+   LHEweights_MultiLepCalc = 0;
    LeptonEnergy_TpTpCalc = 0;
    LeptonEta_TpTpCalc = 0;
    LeptonPhi_TpTpCalc = 0;
@@ -1578,70 +1579,70 @@ void step1::Init(TTree *tree)
    dnn_W_DeepAK8Calc = 0;
    dnn_Z_BestCalc = 0;
    dnn_Z_DeepAK8Calc = 0;
-   elAEff_singleLepCalc = 0;
-   elChIso_singleLepCalc = 0;
-   elD0_singleLepCalc = 0;
-   elDEtaSCTkAtVtx_singleLepCalc = 0;
-   elDPhiSCTkAtVtx_singleLepCalc = 0;
-   elDR03TkSumPt_singleLepCalc = 0;
-   elDZ_singleLepCalc = 0;
-   elDeta_singleLepCalc = 0;
-   elDphi_singleLepCalc = 0;
-   elDxy_singleLepCalc = 0;
-   elEcalPFClusterIso_singleLepCalc = 0;
-   elEnergy_singleLepCalc = 0;
-   elEtaVtx_singleLepCalc = 0;
-   elEta_singleLepCalc = 0;
-   elGen_Reco_dr_singleLepCalc = 0;
-   elHcalPFClusterIso_singleLepCalc = 0;
-   elHoE_singleLepCalc = 0;
-   elIsLooseBarrel_singleLepCalc = 0;
-   elIsLooseEndCap_singleLepCalc = 0;
-   elIsMediumBarrel_singleLepCalc = 0;
-   elIsMediumEndCap_singleLepCalc = 0;
-   elIsTightBarrel_singleLepCalc = 0;
-   elIsTightEndCap_singleLepCalc = 0;
-   elIsVetoBarrel_singleLepCalc = 0;
-   elIsVetoEndCap_singleLepCalc = 0;
-   elMVAValue_iso_singleLepCalc = 0;
-   elMVAValue_singleLepCalc = 0;
-   elMatchedEnergy_singleLepCalc = 0;
-   elMatchedEta_singleLepCalc = 0;
-   elMatchedPhi_singleLepCalc = 0;
-   elMatchedPt_singleLepCalc = 0;
-   elMiniIso_singleLepCalc = 0;
-   elMother_energy_singleLepCalc = 0;
-   elMother_eta_singleLepCalc = 0;
-   elMother_phi_singleLepCalc = 0;
-   elMother_pt_singleLepCalc = 0;
-   elNhIso_singleLepCalc = 0;
+   elAEff_MultiLepCalc = 0;
+   elChIso_MultiLepCalc = 0;
+   elD0_MultiLepCalc = 0;
+   elDEtaSCTkAtVtx_MultiLepCalc = 0;
+   elDPhiSCTkAtVtx_MultiLepCalc = 0;
+   elDR03TkSumPt_MultiLepCalc = 0;
+   elDZ_MultiLepCalc = 0;
+   elDeta_MultiLepCalc = 0;
+   elDphi_MultiLepCalc = 0;
+   elDxy_MultiLepCalc = 0;
+   elEcalPFClusterIso_MultiLepCalc = 0;
+   elEnergy_MultiLepCalc = 0;
+   elEtaVtx_MultiLepCalc = 0;
+   elEta_MultiLepCalc = 0;
+   elGen_Reco_dr_MultiLepCalc = 0;
+   elHcalPFClusterIso_MultiLepCalc = 0;
+   elHoE_MultiLepCalc = 0;
+   elIsLooseBarrel_MultiLepCalc = 0;
+   elIsLooseEndCap_MultiLepCalc = 0;
+   elIsMediumBarrel_MultiLepCalc = 0;
+   elIsMediumEndCap_MultiLepCalc = 0;
+   elIsTightBarrel_MultiLepCalc = 0;
+   elIsTightEndCap_MultiLepCalc = 0;
+   elIsVetoBarrel_MultiLepCalc = 0;
+   elIsVetoEndCap_MultiLepCalc = 0;
+   elMVAValue_iso_MultiLepCalc = 0;
+//   elMVAValue_MultiLepCalc = 0;
+   elMatchedEnergy_MultiLepCalc = 0;
+   elMatchedEta_MultiLepCalc = 0;
+   elMatchedPhi_MultiLepCalc = 0;
+   elMatchedPt_MultiLepCalc = 0;
+   elMiniIso_MultiLepCalc = 0;
+   elMother_energy_MultiLepCalc = 0;
+   elMother_eta_MultiLepCalc = 0;
+   elMother_phi_MultiLepCalc = 0;
+   elMother_pt_MultiLepCalc = 0;
+   elNhIso_MultiLepCalc = 0;
 
-   elOoemoop_singleLepCalc = 0;
-   elPFEta_singleLepCalc = 0;
-   elPFPhi_singleLepCalc = 0;
-   elPhIso_singleLepCalc = 0;
-   elPhiVtx_singleLepCalc = 0;
-   elPhi_singleLepCalc = 0;
-   elPt_singleLepCalc = 0;
-   elRelIso_singleLepCalc = 0;
-   elRhoIso_singleLepCalc = 0;
-   elSCE_singleLepCalc = 0;
-   elSihih_singleLepCalc = 0;
+   elOoemoop_MultiLepCalc = 0;
+   elPFEta_MultiLepCalc = 0;
+   elPFPhi_MultiLepCalc = 0;
+   elPhIso_MultiLepCalc = 0;
+   elPhiVtx_MultiLepCalc = 0;
+   elPhi_MultiLepCalc = 0;
+   elPt_MultiLepCalc = 0;
+   elRelIso_MultiLepCalc = 0;
+   elRhoIso_MultiLepCalc = 0;
+   elSCE_MultiLepCalc = 0;
+   elSihih_MultiLepCalc = 0;
    et_BestCalc = 0;
    eta_BestCalc = 0;
-   evtWeightsMC_singleLepCalc = 0;
-   genBSLEnergy_singleLepCalc = 0;
-   genBSLEta_singleLepCalc = 0;
-   genBSLPhi_singleLepCalc = 0;
-   genBSLPt_singleLepCalc = 0;
-   genEnergy_singleLepCalc = 0;
-   genEta_singleLepCalc = 0;
-   genJetEnergy_singleLepCalc = 0;
-   genJetEta_singleLepCalc = 0;
-   genJetPhi_singleLepCalc = 0;
-   genJetPt_singleLepCalc = 0;
-   genPhi_singleLepCalc = 0;
-   genPt_singleLepCalc = 0;
+   evtWeightsMC_MultiLepCalc = 0;
+   genBSLEnergy_MultiLepCalc = 0;
+   genBSLEta_MultiLepCalc = 0;
+   genBSLPhi_MultiLepCalc = 0;
+   genBSLPt_MultiLepCalc = 0;
+   genEnergy_MultiLepCalc = 0;
+   genEta_MultiLepCalc = 0;
+   genJetEnergy_MultiLepCalc = 0;
+   genJetEta_MultiLepCalc = 0;
+   genJetPhi_MultiLepCalc = 0;
+   genJetPt_MultiLepCalc = 0;
+   genPhi_MultiLepCalc = 0;
+   genPt_MultiLepCalc = 0;
    isotropyH_BestCalc = 0;
    isotropyW_BestCalc = 0;
    isotropyZ_BestCalc = 0;
@@ -1667,32 +1668,32 @@ void step1::Init(TTree *tree)
    m23_jet_BestCalc = 0;
    m23top_BestCalc = 0;
    mass_BestCalc = 0;
-   muChIso_singleLepCalc = 0;
-   muChi2_singleLepCalc = 0;
-   muDxy_singleLepCalc = 0;
-   muDz_singleLepCalc = 0;
-   muEnergy_singleLepCalc = 0;
-   muEta_singleLepCalc = 0;
-   muGIso_singleLepCalc = 0;
-   muGen_Reco_dr_singleLepCalc = 0;
-   muInnerEta_singleLepCalc = 0;
-   muInnerPhi_singleLepCalc = 0;
-   muInnerPt_singleLepCalc = 0;
-   muMatchedEnergy_singleLepCalc = 0;
-   muMatchedEta_singleLepCalc = 0;
-   muMatchedPhi_singleLepCalc = 0;
-   muMatchedPt_singleLepCalc = 0;
-   muMiniIsoDB_singleLepCalc = 0;
-   muMiniIso_singleLepCalc = 0;
-   muMother_energy_singleLepCalc = 0;
-   muMother_eta_singleLepCalc = 0;
-   muMother_phi_singleLepCalc = 0;
-   muMother_pt_singleLepCalc = 0;
-   muNhIso_singleLepCalc = 0;
-   muPhi_singleLepCalc = 0;
-   muPt_singleLepCalc = 0;
-   muPuIso_singleLepCalc = 0;
-   muRelIso_singleLepCalc = 0;
+   muChIso_MultiLepCalc = 0;
+   muChi2_MultiLepCalc = 0;
+   muDxy_MultiLepCalc = 0;
+   muDz_MultiLepCalc = 0;
+   muEnergy_MultiLepCalc = 0;
+   muEta_MultiLepCalc = 0;
+   muGIso_MultiLepCalc = 0;
+   muGen_Reco_dr_MultiLepCalc = 0;
+   muInnerEta_MultiLepCalc = 0;
+   muInnerPhi_MultiLepCalc = 0;
+   muInnerPt_MultiLepCalc = 0;
+   muMatchedEnergy_MultiLepCalc = 0;
+   muMatchedEta_MultiLepCalc = 0;
+   muMatchedPhi_MultiLepCalc = 0;
+   muMatchedPt_MultiLepCalc = 0;
+   muMiniIsoDB_MultiLepCalc = 0;
+   muMiniIso_MultiLepCalc = 0;
+   muMother_energy_MultiLepCalc = 0;
+   muMother_eta_MultiLepCalc = 0;
+   muMother_phi_MultiLepCalc = 0;
+   muMother_pt_MultiLepCalc = 0;
+   muNhIso_MultiLepCalc = 0;
+   muPhi_MultiLepCalc = 0;
+   muPt_MultiLepCalc = 0;
+   muPuIso_MultiLepCalc = 0;
+   muRelIso_MultiLepCalc = 0;
    pzOverp_H_BestCalc = 0;
    pzOverp_W_BestCalc = 0;
    pzOverp_Z_BestCalc = 0;
@@ -1784,20 +1785,20 @@ void step1::Init(TTree *tree)
    topbEta_TTbarMassCalc = 0;
    topbPhi_TTbarMassCalc = 0;
    topbPt_TTbarMassCalc = 0;
-   electron_hltfilters_singleLepCalc = 0;
-   muon_hltfilters_singleLepCalc = 0;
-   vsSelMCTriggersEl_singleLepCalc = 0;
-   vsSelMCTriggersMu_singleLepCalc = 0;
-   vsSelTriggersEl_singleLepCalc = 0;
-   vsSelTriggersMu_singleLepCalc = 0;
+   electron_hltfilters_MultiLepCalc = 0;
+   muon_hltfilters_MultiLepCalc = 0;
+   vsSelMCTriggersEl_MultiLepCalc = 0;
+   vsSelMCTriggersMu_MultiLepCalc = 0;
+   vsSelTriggersEl_MultiLepCalc = 0;
+   vsSelTriggersMu_MultiLepCalc = 0;
    // Set branch addresses and branch pointers
    if (!tree) return;
    inputTree = tree;
    fCurrent = -1;
    inputTree->SetMakeClass(1);
 
-   inputTree->SetBranchAddress("flagBadMu_singleLepCalc", &flagBadMu_singleLepCalc, &b_flagBadMu_singleLepCalc);
-   inputTree->SetBranchAddress("flagDupMu_singleLepCalc", &flagDupMu_singleLepCalc, &b_flagDupMu_singleLepCalc);
+   inputTree->SetBranchAddress("flagBadMu_MultiLepCalc", &flagBadMu_MultiLepCalc, &b_flagBadMu_MultiLepCalc);
+   inputTree->SetBranchAddress("flagDupMu_MultiLepCalc", &flagDupMu_MultiLepCalc, &b_flagDupMu_MultiLepCalc);
    inputTree->SetBranchAddress("isBHBH_TpTpCalc", &isBHBH_TpTpCalc, &b_isBHBH_TpTpCalc);
    inputTree->SetBranchAddress("isBHTW_TpTpCalc", &isBHTW_TpTpCalc, &b_isBHTW_TpTpCalc);
    inputTree->SetBranchAddress("isBWBW_TpTpCalc", &isBWBW_TpTpCalc, &b_isBWBW_TpTpCalc);
@@ -1810,7 +1811,7 @@ void step1::Init(TTree *tree)
    inputTree->SetBranchAddress("isTZBW_TpTpCalc", &isTZBW_TpTpCalc, &b_isTZBW_TpTpCalc);
    inputTree->SetBranchAddress("isTZTH_TpTpCalc", &isTZTH_TpTpCalc, &b_isTZTH_TpTpCalc);
    inputTree->SetBranchAddress("isTZTZ_TpTpCalc", &isTZTZ_TpTpCalc, &b_isTZTZ_TpTpCalc);
-   inputTree->SetBranchAddress("isTau_singleLepCalc", &isTau_singleLepCalc, &b_isTau_singleLepCalc);
+   inputTree->SetBranchAddress("isTau_MultiLepCalc", &isTau_MultiLepCalc, &b_isTau_MultiLepCalc);
    inputTree->SetBranchAddress("NBsFromTTbar_TTbarMassCalc", &NBsFromTTbar_TTbarMassCalc, &b_NBsFromTTbar_TTbarMassCalc);
    inputTree->SetBranchAddress("NCharm_TTbarMassCalc", &NCharm_TTbarMassCalc, &b_NCharm_TTbarMassCalc);
    inputTree->SetBranchAddress("NExtraBs_TTbarMassCalc", &NExtraBs_TTbarMassCalc, &b_NExtraBs_TTbarMassCalc);
@@ -1818,12 +1819,12 @@ void step1::Init(TTree *tree)
    inputTree->SetBranchAddress("NExtraLs_TTbarMassCalc", &NExtraLs_TTbarMassCalc, &b_NExtraLs_TTbarMassCalc);
    inputTree->SetBranchAddress("NLeptonDecays_TpTpCalc", &NLeptonDecays_TpTpCalc, &b_NLeptonDecays_TpTpCalc);
    inputTree->SetBranchAddress("NLight_TTbarMassCalc", &NLight_TTbarMassCalc, &b_NLight_TTbarMassCalc);
-   inputTree->SetBranchAddress("NPartonsfromHEPUEP_singleLepCalc", &NPartonsfromHEPUEP_singleLepCalc, &b_NPartonsfromHEPUEP_singleLepCalc);
+   inputTree->SetBranchAddress("NPartonsfromHEPUEP_MultiLepCalc", &NPartonsfromHEPUEP_MultiLepCalc, &b_NPartonsfromHEPUEP_MultiLepCalc);
    inputTree->SetBranchAddress("NTotalBs_TTbarMassCalc", &NTotalBs_TTbarMassCalc, &b_NTotalBs_TTbarMassCalc);
    inputTree->SetBranchAddress("NWdecaysFromTTbar_TTbarMassCalc", &NWdecaysFromTTbar_TTbarMassCalc, &b_NWdecaysFromTTbar_TTbarMassCalc);
-   inputTree->SetBranchAddress("dataE_singleLepCalc", &dataE_singleLepCalc, &b_dataE_singleLepCalc);
-   inputTree->SetBranchAddress("dataM_singleLepCalc", &dataM_singleLepCalc, &b_dataM_singleLepCalc);
-   inputTree->SetBranchAddress("genTDLID_singleLepCalc", &genTDLID_singleLepCalc, &b_genTDLID_singleLepCalc);
+   inputTree->SetBranchAddress("dataE_MultiLepCalc", &dataE_MultiLepCalc, &b_dataE_MultiLepCalc);
+   inputTree->SetBranchAddress("dataM_MultiLepCalc", &dataM_MultiLepCalc, &b_dataM_MultiLepCalc);
+   inputTree->SetBranchAddress("genTDLID_MultiLepCalc", &genTDLID_MultiLepCalc, &b_genTDLID_MultiLepCalc);
    inputTree->SetBranchAddress("isTT_TTbarMassCalc", &isTT_TTbarMassCalc, &b_isTT_TTbarMassCalc);
    inputTree->SetBranchAddress("isTTbb_TTbarMassCalc", &isTTbb_TTbarMassCalc, &b_isTTbb_TTbarMassCalc);
    inputTree->SetBranchAddress("isTTbj_TTbarMassCalc", &isTTbj_TTbarMassCalc, &b_isTTbj_TTbarMassCalc);
@@ -1834,57 +1835,57 @@ void step1::Init(TTree *tree)
    inputTree->SetBranchAddress("lumi_CommonCalc", &lumi_CommonCalc, &b_lumi_CommonCalc);
    inputTree->SetBranchAddress("nAllJets_CommonCalc", &nAllJets_CommonCalc, &b_nAllJets_CommonCalc);
    inputTree->SetBranchAddress("nLooseMuons_CommonCalc", &nLooseMuons_CommonCalc, &b_nLooseMuons_CommonCalc);
-   inputTree->SetBranchAddress("nPV_singleLepCalc", &nPV_singleLepCalc, &b_nPV_singleLepCalc);
-   inputTree->SetBranchAddress("nPileupInteractions_singleLepCalc", &nPileupInteractions_singleLepCalc, &b_nPileupInteractions_singleLepCalc);
+   inputTree->SetBranchAddress("nPV_MultiLepCalc", &nPV_MultiLepCalc, &b_nPV_MultiLepCalc);
+   inputTree->SetBranchAddress("nPileupInteractions_MultiLepCalc", &nPileupInteractions_MultiLepCalc, &b_nPileupInteractions_MultiLepCalc);
    inputTree->SetBranchAddress("nSelBtagJets_CommonCalc", &nSelBtagJets_CommonCalc, &b_nSelBtagJets_CommonCalc);
    inputTree->SetBranchAddress("nSelElectrons_CommonCalc", &nSelElectrons_CommonCalc, &b_nSelElectrons_CommonCalc);
    inputTree->SetBranchAddress("nSelJets_CommonCalc", &nSelJets_CommonCalc, &b_nSelJets_CommonCalc);
    inputTree->SetBranchAddress("nTightMuons_CommonCalc", &nTightMuons_CommonCalc, &b_nTightMuons_CommonCalc);
-   inputTree->SetBranchAddress("nTrueInteractions_singleLepCalc", &nTrueInteractions_singleLepCalc, &b_nTrueInteractions_singleLepCalc);
+   inputTree->SetBranchAddress("nTrueInteractions_MultiLepCalc", &nTrueInteractions_MultiLepCalc, &b_nTrueInteractions_MultiLepCalc);
    inputTree->SetBranchAddress("run_CommonCalc", &run_CommonCalc, &b_run_CommonCalc);
    inputTree->SetBranchAddress("event_CommonCalc", &event_CommonCalc, &b_event_CommonCalc);
-   inputTree->SetBranchAddress("AK4HT_jerdn_singleLepCalc", &AK4HT_jerdn_singleLepCalc, &b_AK4HT_jerdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK4HT_jerup_singleLepCalc", &AK4HT_jerup_singleLepCalc, &b_AK4HT_jerup_singleLepCalc);
-   inputTree->SetBranchAddress("AK4HT_jesdn_singleLepCalc", &AK4HT_jesdn_singleLepCalc, &b_AK4HT_jesdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK4HT_jesup_singleLepCalc", &AK4HT_jesup_singleLepCalc, &b_AK4HT_jesup_singleLepCalc);
-   inputTree->SetBranchAddress("AK4HT_singleLepCalc", &AK4HT_singleLepCalc, &b_AK4HT_singleLepCalc);
-   inputTree->SetBranchAddress("HTfromHEPUEP_singleLepCalc", &HTfromHEPUEP_singleLepCalc, &b_HTfromHEPUEP_singleLepCalc);
-   inputTree->SetBranchAddress("MCWeight_singleLepCalc", &MCWeight_singleLepCalc, &b_MCWeight_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_jerdn_phi_singleLepCalc", &corr_met_jerdn_phi_singleLepCalc, &b_corr_met_jerdn_phi_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_jerdn_singleLepCalc", &corr_met_jerdn_singleLepCalc, &b_corr_met_jerdn_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_jerup_phi_singleLepCalc", &corr_met_jerup_phi_singleLepCalc, &b_corr_met_jerup_phi_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_jerup_singleLepCalc", &corr_met_jerup_singleLepCalc, &b_corr_met_jerup_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_jesdn_phi_singleLepCalc", &corr_met_jesdn_phi_singleLepCalc, &b_corr_met_jesdn_phi_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_jesdn_singleLepCalc", &corr_met_jesdn_singleLepCalc, &b_corr_met_jesdn_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_jesup_phi_singleLepCalc", &corr_met_jesup_phi_singleLepCalc, &b_corr_met_jesup_phi_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_jesup_singleLepCalc", &corr_met_jesup_singleLepCalc, &b_corr_met_jesup_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_phi_singleLepCalc", &corr_met_phi_singleLepCalc, &b_corr_met_phi_singleLepCalc);
-   inputTree->SetBranchAddress("corr_met_singleLepCalc", &corr_met_singleLepCalc, &b_corr_met_singleLepCalc);
-   inputTree->SetBranchAddress("corr_metnohf_phi_singleLepCalc", &corr_metnohf_phi_singleLepCalc, &b_corr_metnohf_phi_singleLepCalc);
-   inputTree->SetBranchAddress("corr_metnohf_singleLepCalc", &corr_metnohf_singleLepCalc, &b_corr_metnohf_singleLepCalc);
-   inputTree->SetBranchAddress("genTDLEnergy_singleLepCalc", &genTDLEnergy_singleLepCalc, &b_genTDLEnergy_singleLepCalc);
-   inputTree->SetBranchAddress("genTDLEta_singleLepCalc", &genTDLEta_singleLepCalc, &b_genTDLEta_singleLepCalc);
-   inputTree->SetBranchAddress("genTDLPhi_singleLepCalc", &genTDLPhi_singleLepCalc, &b_genTDLPhi_singleLepCalc);
-   inputTree->SetBranchAddress("genTDLPt_singleLepCalc", &genTDLPt_singleLepCalc, &b_genTDLPt_singleLepCalc);
-   inputTree->SetBranchAddress("met_phi_singleLepCalc", &met_phi_singleLepCalc, &b_met_phi_singleLepCalc);
-   inputTree->SetBranchAddress("met_singleLepCalc", &met_singleLepCalc, &b_met_singleLepCalc);
-   inputTree->SetBranchAddress("metnohf_phi_singleLepCalc", &metnohf_phi_singleLepCalc, &b_metnohf_phi_singleLepCalc);
-   inputTree->SetBranchAddress("metnohf_singleLepCalc", &metnohf_singleLepCalc, &b_metnohf_singleLepCalc);
+   inputTree->SetBranchAddress("AK4HT_jerdn_MultiLepCalc", &AK4HT_jerdn_MultiLepCalc, &b_AK4HT_jerdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4HT_jerup_MultiLepCalc", &AK4HT_jerup_MultiLepCalc, &b_AK4HT_jerup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4HT_jesdn_MultiLepCalc", &AK4HT_jesdn_MultiLepCalc, &b_AK4HT_jesdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4HT_jesup_MultiLepCalc", &AK4HT_jesup_MultiLepCalc, &b_AK4HT_jesup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4HT_MultiLepCalc", &AK4HT_MultiLepCalc, &b_AK4HT_MultiLepCalc);
+   inputTree->SetBranchAddress("HTfromHEPUEP_MultiLepCalc", &HTfromHEPUEP_MultiLepCalc, &b_HTfromHEPUEP_MultiLepCalc);
+   inputTree->SetBranchAddress("MCWeight_MultiLepCalc", &MCWeight_MultiLepCalc, &b_MCWeight_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_jerdn_phi_MultiLepCalc", &corr_met_jerdn_phi_MultiLepCalc, &b_corr_met_jerdn_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_jerdn_MultiLepCalc", &corr_met_jerdn_MultiLepCalc, &b_corr_met_jerdn_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_jerup_phi_MultiLepCalc", &corr_met_jerup_phi_MultiLepCalc, &b_corr_met_jerup_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_jerup_MultiLepCalc", &corr_met_jerup_MultiLepCalc, &b_corr_met_jerup_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_jesdn_phi_MultiLepCalc", &corr_met_jesdn_phi_MultiLepCalc, &b_corr_met_jesdn_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_jesdn_MultiLepCalc", &corr_met_jesdn_MultiLepCalc, &b_corr_met_jesdn_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_jesup_phi_MultiLepCalc", &corr_met_jesup_phi_MultiLepCalc, &b_corr_met_jesup_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_jesup_MultiLepCalc", &corr_met_jesup_MultiLepCalc, &b_corr_met_jesup_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_phi_MultiLepCalc", &corr_met_phi_MultiLepCalc, &b_corr_met_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_met_MultiLepCalc", &corr_met_MultiLepCalc, &b_corr_met_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_metnohf_phi_MultiLepCalc", &corr_metnohf_phi_MultiLepCalc, &b_corr_metnohf_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("corr_metnohf_MultiLepCalc", &corr_metnohf_MultiLepCalc, &b_corr_metnohf_MultiLepCalc);
+   inputTree->SetBranchAddress("genTDLEnergy_MultiLepCalc", &genTDLEnergy_MultiLepCalc, &b_genTDLEnergy_MultiLepCalc);
+   inputTree->SetBranchAddress("genTDLEta_MultiLepCalc", &genTDLEta_MultiLepCalc, &b_genTDLEta_MultiLepCalc);
+   inputTree->SetBranchAddress("genTDLPhi_MultiLepCalc", &genTDLPhi_MultiLepCalc, &b_genTDLPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("genTDLPt_MultiLepCalc", &genTDLPt_MultiLepCalc, &b_genTDLPt_MultiLepCalc);
+   inputTree->SetBranchAddress("met_phi_MultiLepCalc", &met_phi_MultiLepCalc, &b_met_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("met_MultiLepCalc", &met_MultiLepCalc, &b_met_MultiLepCalc);
+   inputTree->SetBranchAddress("metnohf_phi_MultiLepCalc", &metnohf_phi_MultiLepCalc, &b_metnohf_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("metnohf_MultiLepCalc", &metnohf_MultiLepCalc, &b_metnohf_MultiLepCalc);
    inputTree->SetBranchAddress("theJetHT_JetSubCalc", &theJetHT_JetSubCalc, &b_theJetHT_JetSubCalc);
    inputTree->SetBranchAddress("theJetLeadPt_JetSubCalc", &theJetLeadPt_JetSubCalc, &b_theJetLeadPt_JetSubCalc);
    inputTree->SetBranchAddress("theJetSubLeadPt_JetSubCalc", &theJetSubLeadPt_JetSubCalc, &b_theJetSubLeadPt_JetSubCalc);
    inputTree->SetBranchAddress("ttbarMass_TTbarMassCalc", &ttbarMass_TTbarMassCalc, &b_ttbarMass_TTbarMassCalc);
-   inputTree->SetBranchAddress("AK4JetBTag_bSFdn_singleLepCalc", &AK4JetBTag_bSFdn_singleLepCalc, &b_AK4JetBTag_bSFdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetBTag_bSFup_singleLepCalc", &AK4JetBTag_bSFup_singleLepCalc, &b_AK4JetBTag_bSFup_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetBTag_lSFdn_singleLepCalc", &AK4JetBTag_lSFdn_singleLepCalc, &b_AK4JetBTag_lSFdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetBTag_lSFup_singleLepCalc", &AK4JetBTag_lSFup_singleLepCalc, &b_AK4JetBTag_lSFup_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetBTag_singleLepCalc", &AK4JetBTag_singleLepCalc, &b_AK4JetBTag_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetFlav_singleLepCalc", &AK4JetFlav_singleLepCalc, &b_AK4JetFlav_singleLepCalc);
+   inputTree->SetBranchAddress("AK4JetBTag_bSFdn_MultiLepCalc", &AK4JetBTag_bSFdn_MultiLepCalc, &b_AK4JetBTag_bSFdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetBTag_bSFup_MultiLepCalc", &AK4JetBTag_bSFup_MultiLepCalc, &b_AK4JetBTag_bSFup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetBTag_lSFdn_MultiLepCalc", &AK4JetBTag_lSFdn_MultiLepCalc, &b_AK4JetBTag_lSFdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetBTag_lSFup_MultiLepCalc", &AK4JetBTag_lSFup_MultiLepCalc, &b_AK4JetBTag_lSFup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetBTag_MultiLepCalc", &AK4JetBTag_MultiLepCalc, &b_AK4JetBTag_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetFlav_MultiLepCalc", &AK4JetFlav_MultiLepCalc, &b_AK4JetFlav_MultiLepCalc);
    inputTree->SetBranchAddress("HadronicVHtID_JetSubCalc", &HadronicVHtID_JetSubCalc, &b_HadronicVHtID_JetSubCalc);
    inputTree->SetBranchAddress("HadronicVHtStatus_JetSubCalc", &HadronicVHtStatus_JetSubCalc, &b_HadronicVHtStatus_JetSubCalc);
    inputTree->SetBranchAddress("HdecayID_TpTpCalc", &HdecayID_TpTpCalc, &b_HdecayID_TpTpCalc);
    inputTree->SetBranchAddress("HdecayIndex_TpTpCalc", &HdecayIndex_TpTpCalc, &b_HdecayIndex_TpTpCalc);
-   inputTree->SetBranchAddress("LHEweightids_singleLepCalc", &LHEweightids_singleLepCalc, &b_LHEweightids_singleLepCalc);
+   inputTree->SetBranchAddress("LHEweightids_MultiLepCalc", &LHEweightids_MultiLepCalc, &b_LHEweightids_MultiLepCalc);
    inputTree->SetBranchAddress("LeptonID_TpTpCalc", &LeptonID_TpTpCalc, &b_LeptonID_TpTpCalc);
    inputTree->SetBranchAddress("LeptonParentID_TpTpCalc", &LeptonParentID_TpTpCalc, &b_LeptonParentID_TpTpCalc);
    inputTree->SetBranchAddress("WdecayID_TpTpCalc", &WdecayID_TpTpCalc, &b_WdecayID_TpTpCalc);
@@ -1901,59 +1902,59 @@ void step1::Init(TTree *tree)
    inputTree->SetBranchAddress("dnn_largest_BestCalc", &dnn_largest_BestCalc, &b_dnn_largest_BestCalc);
    inputTree->SetBranchAddress("dnn_largest_DeepAK8Calc", &dnn_largest_DeepAK8Calc, &b_dnn_largest_DeepAK8Calc);
    inputTree->SetBranchAddress("decorr_largest_DeepAK8Calc", &decorr_largest_DeepAK8Calc, &b_decorr_largest_DeepAK8Calc);
-   inputTree->SetBranchAddress("elChargeConsistent_singleLepCalc", &elChargeConsistent_singleLepCalc, &b_elChargeConsistent_singleLepCalc);
-   inputTree->SetBranchAddress("elCharge_singleLepCalc", &elCharge_singleLepCalc, &b_elCharge_singleLepCalc);
-   inputTree->SetBranchAddress("elCtfCharge_singleLepCalc", &elCtfCharge_singleLepCalc, &b_elCtfCharge_singleLepCalc);
-   inputTree->SetBranchAddress("elGsfCharge_singleLepCalc", &elGsfCharge_singleLepCalc, &b_elGsfCharge_singleLepCalc);
-   inputTree->SetBranchAddress("elIsEBEE_singleLepCalc", &elIsEBEE_singleLepCalc, &b_elIsEBEE_singleLepCalc);
-   inputTree->SetBranchAddress("elIsMVALooseIso_singleLepCalc", &elIsMVALooseIso_singleLepCalc, &b_elIsMVALooseIso_singleLepCalc);
-   inputTree->SetBranchAddress("elIsMVALoose_singleLepCalc", &elIsMVALoose_singleLepCalc, &b_elIsMVALoose_singleLepCalc);
-   inputTree->SetBranchAddress("elIsMVATightIso_singleLepCalc", &elIsMVATightIso_singleLepCalc, &b_elIsMVATightIso_singleLepCalc);
-   inputTree->SetBranchAddress("elIsMVATight_singleLepCalc", &elIsMVATight_singleLepCalc, &b_elIsMVATight_singleLepCalc);
-   inputTree->SetBranchAddress("elMHits_singleLepCalc", &elMHits_singleLepCalc, &b_elMHits_singleLepCalc);
-   inputTree->SetBranchAddress("elMatched_singleLepCalc", &elMatched_singleLepCalc, &b_elMatched_singleLepCalc);
-   inputTree->SetBranchAddress("elMother_id_singleLepCalc", &elMother_id_singleLepCalc, &b_elMother_id_singleLepCalc);
-   inputTree->SetBranchAddress("elMother_status_singleLepCalc", &elMother_status_singleLepCalc, &b_elMother_status_singleLepCalc);
-   inputTree->SetBranchAddress("elNotConversion_singleLepCalc", &elNotConversion_singleLepCalc, &b_elNotConversion_singleLepCalc);
-   inputTree->SetBranchAddress("elNumberOfMothers_singleLepCalc", &elNumberOfMothers_singleLepCalc, &b_elNumberOfMothers_singleLepCalc);
-   inputTree->SetBranchAddress("elPdgId_singleLepCalc", &elPdgId_singleLepCalc, &b_elPdgId_singleLepCalc);
-   inputTree->SetBranchAddress("elScPixCharge_singleLepCalc", &elScPixCharge_singleLepCalc, &b_elScPixCharge_singleLepCalc);
-   inputTree->SetBranchAddress("elStatus_singleLepCalc", &elStatus_singleLepCalc, &b_elStatus_singleLepCalc);
-   inputTree->SetBranchAddress("elVtxFitConv_singleLepCalc", &elVtxFitConv_singleLepCalc, &b_elVtxFitConv_singleLepCalc);
-   inputTree->SetBranchAddress("electron_1_hltmatched_singleLepCalc", &electron_1_hltmatched_singleLepCalc, &b_electron_1_hltmatched_singleLepCalc);
-   inputTree->SetBranchAddress("genBSLID_singleLepCalc", &genBSLID_singleLepCalc, &b_genBSLID_singleLepCalc);
-   inputTree->SetBranchAddress("genID_singleLepCalc", &genID_singleLepCalc, &b_genID_singleLepCalc);
-   inputTree->SetBranchAddress("genIndex_singleLepCalc", &genIndex_singleLepCalc, &b_genIndex_singleLepCalc);
-   inputTree->SetBranchAddress("genMotherID_singleLepCalc", &genMotherID_singleLepCalc, &b_genMotherID_singleLepCalc);
-   inputTree->SetBranchAddress("genMotherIndex_singleLepCalc", &genMotherIndex_singleLepCalc, &b_genMotherIndex_singleLepCalc);
-   inputTree->SetBranchAddress("genStatus_singleLepCalc", &genStatus_singleLepCalc, &b_genStatus_singleLepCalc);
+   inputTree->SetBranchAddress("elChargeConsistent_MultiLepCalc", &elChargeConsistent_MultiLepCalc, &b_elChargeConsistent_MultiLepCalc);
+   inputTree->SetBranchAddress("elCharge_MultiLepCalc", &elCharge_MultiLepCalc, &b_elCharge_MultiLepCalc);
+   inputTree->SetBranchAddress("elCtfCharge_MultiLepCalc", &elCtfCharge_MultiLepCalc, &b_elCtfCharge_MultiLepCalc);
+   inputTree->SetBranchAddress("elGsfCharge_MultiLepCalc", &elGsfCharge_MultiLepCalc, &b_elGsfCharge_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsEBEE_MultiLepCalc", &elIsEBEE_MultiLepCalc, &b_elIsEBEE_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsMVALooseIso_MultiLepCalc", &elIsMVALooseIso_MultiLepCalc, &b_elIsMVALooseIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsMVALoose_MultiLepCalc", &elIsMVALoose_MultiLepCalc, &b_elIsMVALoose_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsMVATightIso_MultiLepCalc", &elIsMVATightIso_MultiLepCalc, &b_elIsMVATightIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsMVATight_MultiLepCalc", &elIsMVATight_MultiLepCalc, &b_elIsMVATight_MultiLepCalc);
+   inputTree->SetBranchAddress("elMHits_MultiLepCalc", &elMHits_MultiLepCalc, &b_elMHits_MultiLepCalc);
+   inputTree->SetBranchAddress("elMatched_MultiLepCalc", &elMatched_MultiLepCalc, &b_elMatched_MultiLepCalc);
+   inputTree->SetBranchAddress("elMother_id_MultiLepCalc", &elMother_id_MultiLepCalc, &b_elMother_id_MultiLepCalc);
+   inputTree->SetBranchAddress("elMother_status_MultiLepCalc", &elMother_status_MultiLepCalc, &b_elMother_status_MultiLepCalc);
+   inputTree->SetBranchAddress("elNotConversion_MultiLepCalc", &elNotConversion_MultiLepCalc, &b_elNotConversion_MultiLepCalc);
+   inputTree->SetBranchAddress("elNumberOfMothers_MultiLepCalc", &elNumberOfMothers_MultiLepCalc, &b_elNumberOfMothers_MultiLepCalc);
+   inputTree->SetBranchAddress("elPdgId_MultiLepCalc", &elPdgId_MultiLepCalc, &b_elPdgId_MultiLepCalc);
+   inputTree->SetBranchAddress("elScPixCharge_MultiLepCalc", &elScPixCharge_MultiLepCalc, &b_elScPixCharge_MultiLepCalc);
+   inputTree->SetBranchAddress("elStatus_MultiLepCalc", &elStatus_MultiLepCalc, &b_elStatus_MultiLepCalc);
+   inputTree->SetBranchAddress("elVtxFitConv_MultiLepCalc", &elVtxFitConv_MultiLepCalc, &b_elVtxFitConv_MultiLepCalc);
+   inputTree->SetBranchAddress("electron_1_hltmatched_MultiLepCalc", &electron_1_hltmatched_MultiLepCalc, &b_electron_1_hltmatched_MultiLepCalc);
+   inputTree->SetBranchAddress("genBSLID_MultiLepCalc", &genBSLID_MultiLepCalc, &b_genBSLID_MultiLepCalc);
+   inputTree->SetBranchAddress("genID_MultiLepCalc", &genID_MultiLepCalc, &b_genID_MultiLepCalc);
+   inputTree->SetBranchAddress("genIndex_MultiLepCalc", &genIndex_MultiLepCalc, &b_genIndex_MultiLepCalc);
+   inputTree->SetBranchAddress("genMotherID_MultiLepCalc", &genMotherID_MultiLepCalc, &b_genMotherID_MultiLepCalc);
+   inputTree->SetBranchAddress("genMotherIndex_MultiLepCalc", &genMotherIndex_MultiLepCalc, &b_genMotherIndex_MultiLepCalc);
+   inputTree->SetBranchAddress("genStatus_MultiLepCalc", &genStatus_MultiLepCalc, &b_genStatus_MultiLepCalc);
    inputTree->SetBranchAddress("genTtbarIdCategory_TTbarMassCalc", &genTtbarIdCategory_TTbarMassCalc, &b_genTtbarIdCategory_TTbarMassCalc);
-   inputTree->SetBranchAddress("muCharge_singleLepCalc", &muCharge_singleLepCalc, &b_muCharge_singleLepCalc);
-   inputTree->SetBranchAddress("muGlobal_singleLepCalc", &muGlobal_singleLepCalc, &b_muGlobal_singleLepCalc);
-   inputTree->SetBranchAddress("muIsGlobalHighPt_singleLepCalc", &muIsGlobalHighPt_singleLepCalc, &b_muIsGlobalHighPt_singleLepCalc);
-   inputTree->SetBranchAddress("muIsLoose_singleLepCalc", &muIsLoose_singleLepCalc, &b_muIsLoose_singleLepCalc);
-   inputTree->SetBranchAddress("muIsMediumPrompt_singleLepCalc", &muIsMediumPrompt_singleLepCalc, &b_muIsMediumPrompt_singleLepCalc);
-   inputTree->SetBranchAddress("muIsMedium_singleLepCalc", &muIsMedium_singleLepCalc, &b_muIsMedium_singleLepCalc);
-   inputTree->SetBranchAddress("muIsMiniIsoLoose_singleLepCalc", &muIsMiniIsoLoose_singleLepCalc, &b_muIsMiniIsoLoose_singleLepCalc);
-   inputTree->SetBranchAddress("muIsMiniIsoMedium_singleLepCalc", &muIsMiniIsoMedium_singleLepCalc, &b_muIsMiniIsoMedium_singleLepCalc);
-   inputTree->SetBranchAddress("muIsMiniIsoTight_singleLepCalc", &muIsMiniIsoTight_singleLepCalc, &b_muIsMiniIsoTight_singleLepCalc);
-   inputTree->SetBranchAddress("muIsMiniIsoVeryTight_singleLepCalc", &muIsMiniIsoVeryTight_singleLepCalc, &b_muIsMiniIsoVeryTight_singleLepCalc);
-   inputTree->SetBranchAddress("muIsMvaLoose_singleLepCalc", &muIsMvaLoose_singleLepCalc, &b_muIsMvaLoose_singleLepCalc);
-   inputTree->SetBranchAddress("muIsMvaMedium_singleLepCalc", &muIsMvaMedium_singleLepCalc, &b_muIsMvaMedium_singleLepCalc);
-   inputTree->SetBranchAddress("muIsMvaTight_singleLepCalc", &muIsMvaTight_singleLepCalc, &b_muIsMvaTight_singleLepCalc);
-   inputTree->SetBranchAddress("muIsTight_singleLepCalc", &muIsTight_singleLepCalc, &b_muIsTight_singleLepCalc);
-   inputTree->SetBranchAddress("muIsTrkHighPt_singleLepCalc", &muIsTrkHighPt_singleLepCalc, &b_muIsTrkHighPt_singleLepCalc);
-   inputTree->SetBranchAddress("muMatched_singleLepCalc", &muMatched_singleLepCalc, &b_muMatched_singleLepCalc);
-   inputTree->SetBranchAddress("muMother_id_singleLepCalc", &muMother_id_singleLepCalc, &b_muMother_id_singleLepCalc);
-   inputTree->SetBranchAddress("muMother_status_singleLepCalc", &muMother_status_singleLepCalc, &b_muMother_status_singleLepCalc);
-   inputTree->SetBranchAddress("muNMatchedStations_singleLepCalc", &muNMatchedStations_singleLepCalc, &b_muNMatchedStations_singleLepCalc);
-   inputTree->SetBranchAddress("muNTrackerLayers_singleLepCalc", &muNTrackerLayers_singleLepCalc, &b_muNTrackerLayers_singleLepCalc);
-   inputTree->SetBranchAddress("muNValMuHits_singleLepCalc", &muNValMuHits_singleLepCalc, &b_muNValMuHits_singleLepCalc);
-   inputTree->SetBranchAddress("muNValPixelHits_singleLepCalc", &muNValPixelHits_singleLepCalc, &b_muNValPixelHits_singleLepCalc);
-   inputTree->SetBranchAddress("muNumberOfMothers_singleLepCalc", &muNumberOfMothers_singleLepCalc, &b_muNumberOfMothers_singleLepCalc);
-   inputTree->SetBranchAddress("muPdgId_singleLepCalc", &muPdgId_singleLepCalc, &b_muPdgId_singleLepCalc);
-   inputTree->SetBranchAddress("muStatus_singleLepCalc", &muStatus_singleLepCalc, &b_muStatus_singleLepCalc);
-   inputTree->SetBranchAddress("muon_1_hltmatched_singleLepCalc", &muon_1_hltmatched_singleLepCalc, &b_muon_1_hltmatched_singleLepCalc);
+   inputTree->SetBranchAddress("muCharge_MultiLepCalc", &muCharge_MultiLepCalc, &b_muCharge_MultiLepCalc);
+   inputTree->SetBranchAddress("muGlobal_MultiLepCalc", &muGlobal_MultiLepCalc, &b_muGlobal_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsGlobalHighPt_MultiLepCalc", &muIsGlobalHighPt_MultiLepCalc, &b_muIsGlobalHighPt_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsLoose_MultiLepCalc", &muIsLoose_MultiLepCalc, &b_muIsLoose_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsMediumPrompt_MultiLepCalc", &muIsMediumPrompt_MultiLepCalc, &b_muIsMediumPrompt_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsMedium_MultiLepCalc", &muIsMedium_MultiLepCalc, &b_muIsMedium_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsMiniIsoLoose_MultiLepCalc", &muIsMiniIsoLoose_MultiLepCalc, &b_muIsMiniIsoLoose_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsMiniIsoMedium_MultiLepCalc", &muIsMiniIsoMedium_MultiLepCalc, &b_muIsMiniIsoMedium_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsMiniIsoTight_MultiLepCalc", &muIsMiniIsoTight_MultiLepCalc, &b_muIsMiniIsoTight_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsMiniIsoVeryTight_MultiLepCalc", &muIsMiniIsoVeryTight_MultiLepCalc, &b_muIsMiniIsoVeryTight_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsMvaLoose_MultiLepCalc", &muIsMvaLoose_MultiLepCalc, &b_muIsMvaLoose_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsMvaMedium_MultiLepCalc", &muIsMvaMedium_MultiLepCalc, &b_muIsMvaMedium_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsMvaTight_MultiLepCalc", &muIsMvaTight_MultiLepCalc, &b_muIsMvaTight_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsTight_MultiLepCalc", &muIsTight_MultiLepCalc, &b_muIsTight_MultiLepCalc);
+   inputTree->SetBranchAddress("muIsTrkHighPt_MultiLepCalc", &muIsTrkHighPt_MultiLepCalc, &b_muIsTrkHighPt_MultiLepCalc);
+   inputTree->SetBranchAddress("muMatched_MultiLepCalc", &muMatched_MultiLepCalc, &b_muMatched_MultiLepCalc);
+   inputTree->SetBranchAddress("muMother_id_MultiLepCalc", &muMother_id_MultiLepCalc, &b_muMother_id_MultiLepCalc);
+   inputTree->SetBranchAddress("muMother_status_MultiLepCalc", &muMother_status_MultiLepCalc, &b_muMother_status_MultiLepCalc);
+   inputTree->SetBranchAddress("muNMatchedStations_MultiLepCalc", &muNMatchedStations_MultiLepCalc, &b_muNMatchedStations_MultiLepCalc);
+   inputTree->SetBranchAddress("muNTrackerLayers_MultiLepCalc", &muNTrackerLayers_MultiLepCalc, &b_muNTrackerLayers_MultiLepCalc);
+   inputTree->SetBranchAddress("muNValMuHits_MultiLepCalc", &muNValMuHits_MultiLepCalc, &b_muNValMuHits_MultiLepCalc);
+   inputTree->SetBranchAddress("muNValPixelHits_MultiLepCalc", &muNValPixelHits_MultiLepCalc, &b_muNValPixelHits_MultiLepCalc);
+   inputTree->SetBranchAddress("muNumberOfMothers_MultiLepCalc", &muNumberOfMothers_MultiLepCalc, &b_muNumberOfMothers_MultiLepCalc);
+   inputTree->SetBranchAddress("muPdgId_MultiLepCalc", &muPdgId_MultiLepCalc, &b_muPdgId_MultiLepCalc);
+   inputTree->SetBranchAddress("muStatus_MultiLepCalc", &muStatus_MultiLepCalc, &b_muStatus_MultiLepCalc);
+   inputTree->SetBranchAddress("muon_1_hltmatched_MultiLepCalc", &muon_1_hltmatched_MultiLepCalc, &b_muon_1_hltmatched_MultiLepCalc);
    inputTree->SetBranchAddress("quarkID_TpTpCalc", &quarkID_TpTpCalc, &b_quarkID_TpTpCalc);
    inputTree->SetBranchAddress("tPrimeID_TpTpCalc", &tPrimeID_TpTpCalc, &b_tPrimeID_TpTpCalc);
    inputTree->SetBranchAddress("tPrimeNDaughters_TpTpCalc", &tPrimeNDaughters_TpTpCalc, &b_tPrimeNDaughters_TpTpCalc);
@@ -1981,45 +1982,45 @@ void step1::Init(TTree *tree)
    inputTree->SetBranchAddress("topID_TTbarMassCalc", &topID_TTbarMassCalc, &b_topID_TTbarMassCalc);
    inputTree->SetBranchAddress("topWID_TTbarMassCalc", &topWID_TTbarMassCalc, &b_topWID_TTbarMassCalc);
    inputTree->SetBranchAddress("topbID_TTbarMassCalc", &topbID_TTbarMassCalc, &b_topbID_TTbarMassCalc);
-   inputTree->SetBranchAddress("viSelMCTriggersEl_singleLepCalc", &viSelMCTriggersEl_singleLepCalc, &b_viSelMCTriggersEl_singleLepCalc);
-   inputTree->SetBranchAddress("viSelMCTriggersMu_singleLepCalc", &viSelMCTriggersMu_singleLepCalc, &b_viSelMCTriggersMu_singleLepCalc);
-   inputTree->SetBranchAddress("viSelTriggersEl_singleLepCalc", &viSelTriggersEl_singleLepCalc, &b_viSelTriggersEl_singleLepCalc);
-   inputTree->SetBranchAddress("viSelTriggersMu_singleLepCalc", &viSelTriggersMu_singleLepCalc, &b_viSelTriggersMu_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetBDeepCSVb_singleLepCalc", &AK4JetBDeepCSVb_singleLepCalc, &b_AK4JetBDeepCSVb_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetBDeepCSVbb_singleLepCalc", &AK4JetBDeepCSVbb_singleLepCalc, &b_AK4JetBDeepCSVbb_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetBDeepCSVc_singleLepCalc", &AK4JetBDeepCSVc_singleLepCalc, &b_AK4JetBDeepCSVc_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetBDeepCSVudsg_singleLepCalc", &AK4JetBDeepCSVudsg_singleLepCalc, &b_AK4JetBDeepCSVudsg_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetBDisc_singleLepCalc", &AK4JetBDisc_singleLepCalc, &b_AK4JetBDisc_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetEnergy_jerdn_singleLepCalc", &AK4JetEnergy_jerdn_singleLepCalc, &b_AK4JetEnergy_jerdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetEnergy_jerup_singleLepCalc", &AK4JetEnergy_jerup_singleLepCalc, &b_AK4JetEnergy_jerup_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetEnergy_jesdn_singleLepCalc", &AK4JetEnergy_jesdn_singleLepCalc, &b_AK4JetEnergy_jesdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetEnergy_jesup_singleLepCalc", &AK4JetEnergy_jesup_singleLepCalc, &b_AK4JetEnergy_jesup_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetEnergy_singleLepCalc", &AK4JetEnergy_singleLepCalc, &b_AK4JetEnergy_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetEta_singleLepCalc", &AK4JetEta_singleLepCalc, &b_AK4JetEta_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetPhi_singleLepCalc", &AK4JetPhi_singleLepCalc, &b_AK4JetPhi_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetPt_jerdn_singleLepCalc", &AK4JetPt_jerdn_singleLepCalc, &b_AK4JetPt_jerdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetPt_jerup_singleLepCalc", &AK4JetPt_jerup_singleLepCalc, &b_AK4JetPt_jerup_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetPt_jesdn_singleLepCalc", &AK4JetPt_jesdn_singleLepCalc, &b_AK4JetPt_jesdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetPt_jesup_singleLepCalc", &AK4JetPt_jesup_singleLepCalc, &b_AK4JetPt_jesup_singleLepCalc);
-   inputTree->SetBranchAddress("AK4JetPt_singleLepCalc", &AK4JetPt_singleLepCalc, &b_AK4JetPt_singleLepCalc);
+   inputTree->SetBranchAddress("viSelMCTriggersEl_MultiLepCalc", &viSelMCTriggersEl_MultiLepCalc, &b_viSelMCTriggersEl_MultiLepCalc);
+   inputTree->SetBranchAddress("viSelMCTriggersMu_MultiLepCalc", &viSelMCTriggersMu_MultiLepCalc, &b_viSelMCTriggersMu_MultiLepCalc);
+   inputTree->SetBranchAddress("viSelTriggersEl_MultiLepCalc", &viSelTriggersEl_MultiLepCalc, &b_viSelTriggersEl_MultiLepCalc);
+   inputTree->SetBranchAddress("viSelTriggersMu_MultiLepCalc", &viSelTriggersMu_MultiLepCalc, &b_viSelTriggersMu_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetBDeepCSVb_MultiLepCalc", &AK4JetBDeepCSVb_MultiLepCalc, &b_AK4JetBDeepCSVb_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetBDeepCSVbb_MultiLepCalc", &AK4JetBDeepCSVbb_MultiLepCalc, &b_AK4JetBDeepCSVbb_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetBDeepCSVc_MultiLepCalc", &AK4JetBDeepCSVc_MultiLepCalc, &b_AK4JetBDeepCSVc_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetBDeepCSVudsg_MultiLepCalc", &AK4JetBDeepCSVudsg_MultiLepCalc, &b_AK4JetBDeepCSVudsg_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetBDisc_MultiLepCalc", &AK4JetBDisc_MultiLepCalc, &b_AK4JetBDisc_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetEnergy_jerdn_MultiLepCalc", &AK4JetEnergy_jerdn_MultiLepCalc, &b_AK4JetEnergy_jerdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetEnergy_jerup_MultiLepCalc", &AK4JetEnergy_jerup_MultiLepCalc, &b_AK4JetEnergy_jerup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetEnergy_jesdn_MultiLepCalc", &AK4JetEnergy_jesdn_MultiLepCalc, &b_AK4JetEnergy_jesdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetEnergy_jesup_MultiLepCalc", &AK4JetEnergy_jesup_MultiLepCalc, &b_AK4JetEnergy_jesup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetEnergy_MultiLepCalc", &AK4JetEnergy_MultiLepCalc, &b_AK4JetEnergy_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetEta_MultiLepCalc", &AK4JetEta_MultiLepCalc, &b_AK4JetEta_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetPhi_MultiLepCalc", &AK4JetPhi_MultiLepCalc, &b_AK4JetPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetPt_jerdn_MultiLepCalc", &AK4JetPt_jerdn_MultiLepCalc, &b_AK4JetPt_jerdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetPt_jerup_MultiLepCalc", &AK4JetPt_jerup_MultiLepCalc, &b_AK4JetPt_jerup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetPt_jesdn_MultiLepCalc", &AK4JetPt_jesdn_MultiLepCalc, &b_AK4JetPt_jesdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetPt_jesup_MultiLepCalc", &AK4JetPt_jesup_MultiLepCalc, &b_AK4JetPt_jesup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK4JetPt_MultiLepCalc", &AK4JetPt_MultiLepCalc, &b_AK4JetPt_MultiLepCalc);
    inputTree->SetBranchAddress("AK8JetCSV_BestCalc", &AK8JetCSV_BestCalc, &b_AK8JetCSV_BestCalc);
-   inputTree->SetBranchAddress("AK8JetCSV_singleLepCalc", &AK8JetCSV_singleLepCalc, &b_AK8JetCSV_singleLepCalc);
+   inputTree->SetBranchAddress("AK8JetCSV_MultiLepCalc", &AK8JetCSV_MultiLepCalc, &b_AK8JetCSV_MultiLepCalc);
    inputTree->SetBranchAddress("AK8JetEnergy_BestCalc", &AK8JetEnergy_BestCalc, &b_AK8JetEnergy_BestCalc);
-   inputTree->SetBranchAddress("AK8JetEnergy_jerdn_singleLepCalc", &AK8JetEnergy_jerdn_singleLepCalc, &b_AK8JetEnergy_jerdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK8JetEnergy_jerup_singleLepCalc", &AK8JetEnergy_jerup_singleLepCalc, &b_AK8JetEnergy_jerup_singleLepCalc);
-   inputTree->SetBranchAddress("AK8JetEnergy_jesdn_singleLepCalc", &AK8JetEnergy_jesdn_singleLepCalc, &b_AK8JetEnergy_jesdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK8JetEnergy_jesup_singleLepCalc", &AK8JetEnergy_jesup_singleLepCalc, &b_AK8JetEnergy_jesup_singleLepCalc);
-   inputTree->SetBranchAddress("AK8JetEnergy_singleLepCalc", &AK8JetEnergy_singleLepCalc, &b_AK8JetEnergy_singleLepCalc);
+   inputTree->SetBranchAddress("AK8JetEnergy_jerdn_MultiLepCalc", &AK8JetEnergy_jerdn_MultiLepCalc, &b_AK8JetEnergy_jerdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK8JetEnergy_jerup_MultiLepCalc", &AK8JetEnergy_jerup_MultiLepCalc, &b_AK8JetEnergy_jerup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK8JetEnergy_jesdn_MultiLepCalc", &AK8JetEnergy_jesdn_MultiLepCalc, &b_AK8JetEnergy_jesdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK8JetEnergy_jesup_MultiLepCalc", &AK8JetEnergy_jesup_MultiLepCalc, &b_AK8JetEnergy_jesup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK8JetEnergy_MultiLepCalc", &AK8JetEnergy_MultiLepCalc, &b_AK8JetEnergy_MultiLepCalc);
    inputTree->SetBranchAddress("AK8JetEta_BestCalc", &AK8JetEta_BestCalc, &b_AK8JetEta_BestCalc);
-   inputTree->SetBranchAddress("AK8JetEta_singleLepCalc", &AK8JetEta_singleLepCalc, &b_AK8JetEta_singleLepCalc);
+   inputTree->SetBranchAddress("AK8JetEta_MultiLepCalc", &AK8JetEta_MultiLepCalc, &b_AK8JetEta_MultiLepCalc);
    inputTree->SetBranchAddress("AK8JetPhi_BestCalc", &AK8JetPhi_BestCalc, &b_AK8JetPhi_BestCalc);
-   inputTree->SetBranchAddress("AK8JetPhi_singleLepCalc", &AK8JetPhi_singleLepCalc, &b_AK8JetPhi_singleLepCalc);
+   inputTree->SetBranchAddress("AK8JetPhi_MultiLepCalc", &AK8JetPhi_MultiLepCalc, &b_AK8JetPhi_MultiLepCalc);
    inputTree->SetBranchAddress("AK8JetPt_BestCalc", &AK8JetPt_BestCalc, &b_AK8JetPt_BestCalc);
-   inputTree->SetBranchAddress("AK8JetPt_jerdn_singleLepCalc", &AK8JetPt_jerdn_singleLepCalc, &b_AK8JetPt_jerdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK8JetPt_jerup_singleLepCalc", &AK8JetPt_jerup_singleLepCalc, &b_AK8JetPt_jerup_singleLepCalc);
-   inputTree->SetBranchAddress("AK8JetPt_jesdn_singleLepCalc", &AK8JetPt_jesdn_singleLepCalc, &b_AK8JetPt_jesdn_singleLepCalc);
-   inputTree->SetBranchAddress("AK8JetPt_jesup_singleLepCalc", &AK8JetPt_jesup_singleLepCalc, &b_AK8JetPt_jesup_singleLepCalc);
-   inputTree->SetBranchAddress("AK8JetPt_singleLepCalc", &AK8JetPt_singleLepCalc, &b_AK8JetPt_singleLepCalc);
+   inputTree->SetBranchAddress("AK8JetPt_jerdn_MultiLepCalc", &AK8JetPt_jerdn_MultiLepCalc, &b_AK8JetPt_jerdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK8JetPt_jerup_MultiLepCalc", &AK8JetPt_jerup_MultiLepCalc, &b_AK8JetPt_jerup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK8JetPt_jesdn_MultiLepCalc", &AK8JetPt_jesdn_MultiLepCalc, &b_AK8JetPt_jesdn_MultiLepCalc);
+   inputTree->SetBranchAddress("AK8JetPt_jesup_MultiLepCalc", &AK8JetPt_jesup_MultiLepCalc, &b_AK8JetPt_jesup_MultiLepCalc);
+   inputTree->SetBranchAddress("AK8JetPt_MultiLepCalc", &AK8JetPt_MultiLepCalc, &b_AK8JetPt_MultiLepCalc);
    inputTree->SetBranchAddress("FWmoment1H_BestCalc", &FWmoment1H_BestCalc, &b_FWmoment1H_BestCalc);
    inputTree->SetBranchAddress("FWmoment1W_BestCalc", &FWmoment1W_BestCalc, &b_FWmoment1W_BestCalc);
    inputTree->SetBranchAddress("FWmoment1Z_BestCalc", &FWmoment1Z_BestCalc, &b_FWmoment1Z_BestCalc);
@@ -2056,7 +2057,7 @@ void step1::Init(TTree *tree)
    inputTree->SetBranchAddress("HdecayEta_TpTpCalc", &HdecayEta_TpTpCalc, &b_HdecayEta_TpTpCalc);
    inputTree->SetBranchAddress("HdecayPhi_TpTpCalc", &HdecayPhi_TpTpCalc, &b_HdecayPhi_TpTpCalc);
    inputTree->SetBranchAddress("HdecayPt_TpTpCalc", &HdecayPt_TpTpCalc, &b_HdecayPt_TpTpCalc);
-   inputTree->SetBranchAddress("LHEweights_singleLepCalc", &LHEweights_singleLepCalc, &b_LHEweights_singleLepCalc);
+   inputTree->SetBranchAddress("LHEweights_MultiLepCalc", &LHEweights_MultiLepCalc, &b_LHEweights_MultiLepCalc);
    inputTree->SetBranchAddress("LeptonEnergy_TpTpCalc", &LeptonEnergy_TpTpCalc, &b_LeptonEnergy_TpTpCalc);
    inputTree->SetBranchAddress("LeptonEta_TpTpCalc", &LeptonEta_TpTpCalc, &b_LeptonEta_TpTpCalc);
    inputTree->SetBranchAddress("LeptonPhi_TpTpCalc", &LeptonPhi_TpTpCalc, &b_LeptonPhi_TpTpCalc);
@@ -2114,69 +2115,69 @@ void step1::Init(TTree *tree)
    inputTree->SetBranchAddress("dnn_W_DeepAK8Calc", &dnn_W_DeepAK8Calc, &b_dnn_W_DeepAK8Calc);
    inputTree->SetBranchAddress("dnn_Z_BestCalc", &dnn_Z_BestCalc, &b_dnn_Z_BestCalc);
    inputTree->SetBranchAddress("dnn_Z_DeepAK8Calc", &dnn_Z_DeepAK8Calc, &b_dnn_Z_DeepAK8Calc);
-   inputTree->SetBranchAddress("elAEff_singleLepCalc", &elAEff_singleLepCalc, &b_elAEff_singleLepCalc);
-   inputTree->SetBranchAddress("elChIso_singleLepCalc", &elChIso_singleLepCalc, &b_elChIso_singleLepCalc);
-   inputTree->SetBranchAddress("elD0_singleLepCalc", &elD0_singleLepCalc, &b_elD0_singleLepCalc);
-   inputTree->SetBranchAddress("elDEtaSCTkAtVtx_singleLepCalc", &elDEtaSCTkAtVtx_singleLepCalc, &b_elDEtaSCTkAtVtx_singleLepCalc);
-   inputTree->SetBranchAddress("elDPhiSCTkAtVtx_singleLepCalc", &elDPhiSCTkAtVtx_singleLepCalc, &b_elDPhiSCTkAtVtx_singleLepCalc);
-   inputTree->SetBranchAddress("elDR03TkSumPt_singleLepCalc", &elDR03TkSumPt_singleLepCalc, &b_elDR03TkSumPt_singleLepCalc);
-   inputTree->SetBranchAddress("elDZ_singleLepCalc", &elDZ_singleLepCalc, &b_elDZ_singleLepCalc);
-   inputTree->SetBranchAddress("elDeta_singleLepCalc", &elDeta_singleLepCalc, &b_elDeta_singleLepCalc);
-   inputTree->SetBranchAddress("elDphi_singleLepCalc", &elDphi_singleLepCalc, &b_elDphi_singleLepCalc);
-   inputTree->SetBranchAddress("elDxy_singleLepCalc", &elDxy_singleLepCalc, &b_elDxy_singleLepCalc);
-   inputTree->SetBranchAddress("elEcalPFClusterIso_singleLepCalc", &elEcalPFClusterIso_singleLepCalc, &b_elEcalPFClusterIso_singleLepCalc);
-   inputTree->SetBranchAddress("elEnergy_singleLepCalc", &elEnergy_singleLepCalc, &b_elEnergy_singleLepCalc);
-   inputTree->SetBranchAddress("elEtaVtx_singleLepCalc", &elEtaVtx_singleLepCalc, &b_elEtaVtx_singleLepCalc);
-   inputTree->SetBranchAddress("elEta_singleLepCalc", &elEta_singleLepCalc, &b_elEta_singleLepCalc);
-   inputTree->SetBranchAddress("elGen_Reco_dr_singleLepCalc", &elGen_Reco_dr_singleLepCalc, &b_elGen_Reco_dr_singleLepCalc);
-   inputTree->SetBranchAddress("elHcalPFClusterIso_singleLepCalc", &elHcalPFClusterIso_singleLepCalc, &b_elHcalPFClusterIso_singleLepCalc);
-   inputTree->SetBranchAddress("elHoE_singleLepCalc", &elHoE_singleLepCalc, &b_elHoE_singleLepCalc);
-   inputTree->SetBranchAddress("elIsLooseBarrel_singleLepCalc", &elIsLooseBarrel_singleLepCalc, &b_elIsLooseBarrel_singleLepCalc);
-   inputTree->SetBranchAddress("elIsLooseEndCap_singleLepCalc", &elIsLooseEndCap_singleLepCalc, &b_elIsLooseEndCap_singleLepCalc);
-   inputTree->SetBranchAddress("elIsMediumBarrel_singleLepCalc", &elIsMediumBarrel_singleLepCalc, &b_elIsMediumBarrel_singleLepCalc);
-   inputTree->SetBranchAddress("elIsMediumEndCap_singleLepCalc", &elIsMediumEndCap_singleLepCalc, &b_elIsMediumEndCap_singleLepCalc);
-   inputTree->SetBranchAddress("elIsTightBarrel_singleLepCalc", &elIsTightBarrel_singleLepCalc, &b_elIsTightBarrel_singleLepCalc);
-   inputTree->SetBranchAddress("elIsTightEndCap_singleLepCalc", &elIsTightEndCap_singleLepCalc, &b_elIsTightEndCap_singleLepCalc);
-   inputTree->SetBranchAddress("elIsVetoBarrel_singleLepCalc", &elIsVetoBarrel_singleLepCalc, &b_elIsVetoBarrel_singleLepCalc);
-   inputTree->SetBranchAddress("elIsVetoEndCap_singleLepCalc", &elIsVetoEndCap_singleLepCalc, &b_elIsVetoEndCap_singleLepCalc);
-   inputTree->SetBranchAddress("elMVAValue_iso_singleLepCalc", &elMVAValue_iso_singleLepCalc, &b_elMVAValue_iso_singleLepCalc);
-   inputTree->SetBranchAddress("elMVAValue_singleLepCalc", &elMVAValue_singleLepCalc, &b_elMVAValue_singleLepCalc);
-   inputTree->SetBranchAddress("elMatchedEnergy_singleLepCalc", &elMatchedEnergy_singleLepCalc, &b_elMatchedEnergy_singleLepCalc);
-   inputTree->SetBranchAddress("elMatchedEta_singleLepCalc", &elMatchedEta_singleLepCalc, &b_elMatchedEta_singleLepCalc);
-   inputTree->SetBranchAddress("elMatchedPhi_singleLepCalc", &elMatchedPhi_singleLepCalc, &b_elMatchedPhi_singleLepCalc);
-   inputTree->SetBranchAddress("elMatchedPt_singleLepCalc", &elMatchedPt_singleLepCalc, &b_elMatchedPt_singleLepCalc);
-   inputTree->SetBranchAddress("elMiniIso_singleLepCalc", &elMiniIso_singleLepCalc, &b_elMiniIso_singleLepCalc);
-   inputTree->SetBranchAddress("elMother_energy_singleLepCalc", &elMother_energy_singleLepCalc, &b_elMother_energy_singleLepCalc);
-   inputTree->SetBranchAddress("elMother_eta_singleLepCalc", &elMother_eta_singleLepCalc, &b_elMother_eta_singleLepCalc);
-   inputTree->SetBranchAddress("elMother_phi_singleLepCalc", &elMother_phi_singleLepCalc, &b_elMother_phi_singleLepCalc);
-   inputTree->SetBranchAddress("elMother_pt_singleLepCalc", &elMother_pt_singleLepCalc, &b_elMother_pt_singleLepCalc);
-   inputTree->SetBranchAddress("elNhIso_singleLepCalc", &elNhIso_singleLepCalc, &b_elNhIso_singleLepCalc);
-   inputTree->SetBranchAddress("elOoemoop_singleLepCalc", &elOoemoop_singleLepCalc, &b_elOoemoop_singleLepCalc);
-   inputTree->SetBranchAddress("elPFEta_singleLepCalc", &elPFEta_singleLepCalc, &b_elPFEta_singleLepCalc);
-   inputTree->SetBranchAddress("elPFPhi_singleLepCalc", &elPFPhi_singleLepCalc, &b_elPFPhi_singleLepCalc);
-   inputTree->SetBranchAddress("elPhIso_singleLepCalc", &elPhIso_singleLepCalc, &b_elPhIso_singleLepCalc);
-   inputTree->SetBranchAddress("elPhiVtx_singleLepCalc", &elPhiVtx_singleLepCalc, &b_elPhiVtx_singleLepCalc);
-   inputTree->SetBranchAddress("elPhi_singleLepCalc", &elPhi_singleLepCalc, &b_elPhi_singleLepCalc);
-   inputTree->SetBranchAddress("elPt_singleLepCalc", &elPt_singleLepCalc, &b_elPt_singleLepCalc);
-   inputTree->SetBranchAddress("elRelIso_singleLepCalc", &elRelIso_singleLepCalc, &b_elRelIso_singleLepCalc);
-   inputTree->SetBranchAddress("elRhoIso_singleLepCalc", &elRhoIso_singleLepCalc, &b_elRhoIso_singleLepCalc);
-   inputTree->SetBranchAddress("elSCE_singleLepCalc", &elSCE_singleLepCalc, &b_elSCE_singleLepCalc);
-   inputTree->SetBranchAddress("elSihih_singleLepCalc", &elSihih_singleLepCalc, &b_elSihih_singleLepCalc);
+   inputTree->SetBranchAddress("elAEff_MultiLepCalc", &elAEff_MultiLepCalc, &b_elAEff_MultiLepCalc);
+   inputTree->SetBranchAddress("elChIso_MultiLepCalc", &elChIso_MultiLepCalc, &b_elChIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elD0_MultiLepCalc", &elD0_MultiLepCalc, &b_elD0_MultiLepCalc);
+   inputTree->SetBranchAddress("elDEtaSCTkAtVtx_MultiLepCalc", &elDEtaSCTkAtVtx_MultiLepCalc, &b_elDEtaSCTkAtVtx_MultiLepCalc);
+   inputTree->SetBranchAddress("elDPhiSCTkAtVtx_MultiLepCalc", &elDPhiSCTkAtVtx_MultiLepCalc, &b_elDPhiSCTkAtVtx_MultiLepCalc);
+   inputTree->SetBranchAddress("elDR03TkSumPt_MultiLepCalc", &elDR03TkSumPt_MultiLepCalc, &b_elDR03TkSumPt_MultiLepCalc);
+   inputTree->SetBranchAddress("elDZ_MultiLepCalc", &elDZ_MultiLepCalc, &b_elDZ_MultiLepCalc);
+   inputTree->SetBranchAddress("elDeta_MultiLepCalc", &elDeta_MultiLepCalc, &b_elDeta_MultiLepCalc);
+   inputTree->SetBranchAddress("elDphi_MultiLepCalc", &elDphi_MultiLepCalc, &b_elDphi_MultiLepCalc);
+   inputTree->SetBranchAddress("elDxy_MultiLepCalc", &elDxy_MultiLepCalc, &b_elDxy_MultiLepCalc);
+   inputTree->SetBranchAddress("elEcalPFClusterIso_MultiLepCalc", &elEcalPFClusterIso_MultiLepCalc, &b_elEcalPFClusterIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elEnergy_MultiLepCalc", &elEnergy_MultiLepCalc, &b_elEnergy_MultiLepCalc);
+   inputTree->SetBranchAddress("elEtaVtx_MultiLepCalc", &elEtaVtx_MultiLepCalc, &b_elEtaVtx_MultiLepCalc);
+   inputTree->SetBranchAddress("elEta_MultiLepCalc", &elEta_MultiLepCalc, &b_elEta_MultiLepCalc);
+   inputTree->SetBranchAddress("elGen_Reco_dr_MultiLepCalc", &elGen_Reco_dr_MultiLepCalc, &b_elGen_Reco_dr_MultiLepCalc);
+   inputTree->SetBranchAddress("elHcalPFClusterIso_MultiLepCalc", &elHcalPFClusterIso_MultiLepCalc, &b_elHcalPFClusterIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elHoE_MultiLepCalc", &elHoE_MultiLepCalc, &b_elHoE_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsLooseBarrel_MultiLepCalc", &elIsLooseBarrel_MultiLepCalc, &b_elIsLooseBarrel_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsLooseEndCap_MultiLepCalc", &elIsLooseEndCap_MultiLepCalc, &b_elIsLooseEndCap_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsMediumBarrel_MultiLepCalc", &elIsMediumBarrel_MultiLepCalc, &b_elIsMediumBarrel_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsMediumEndCap_MultiLepCalc", &elIsMediumEndCap_MultiLepCalc, &b_elIsMediumEndCap_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsTightBarrel_MultiLepCalc", &elIsTightBarrel_MultiLepCalc, &b_elIsTightBarrel_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsTightEndCap_MultiLepCalc", &elIsTightEndCap_MultiLepCalc, &b_elIsTightEndCap_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsVetoBarrel_MultiLepCalc", &elIsVetoBarrel_MultiLepCalc, &b_elIsVetoBarrel_MultiLepCalc);
+   inputTree->SetBranchAddress("elIsVetoEndCap_MultiLepCalc", &elIsVetoEndCap_MultiLepCalc, &b_elIsVetoEndCap_MultiLepCalc);
+   inputTree->SetBranchAddress("elMVAValue_iso_MultiLepCalc", &elMVAValue_iso_MultiLepCalc, &b_elMVAValue_iso_MultiLepCalc);
+//   inputTree->SetBranchAddress("elMVAValue_MultiLepCalc", &elMVAValue_MultiLepCalc, &b_elMVAValue_MultiLepCalc);
+   inputTree->SetBranchAddress("elMatchedEnergy_MultiLepCalc", &elMatchedEnergy_MultiLepCalc, &b_elMatchedEnergy_MultiLepCalc);
+   inputTree->SetBranchAddress("elMatchedEta_MultiLepCalc", &elMatchedEta_MultiLepCalc, &b_elMatchedEta_MultiLepCalc);
+   inputTree->SetBranchAddress("elMatchedPhi_MultiLepCalc", &elMatchedPhi_MultiLepCalc, &b_elMatchedPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("elMatchedPt_MultiLepCalc", &elMatchedPt_MultiLepCalc, &b_elMatchedPt_MultiLepCalc);
+   inputTree->SetBranchAddress("elMiniIso_MultiLepCalc", &elMiniIso_MultiLepCalc, &b_elMiniIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elMother_energy_MultiLepCalc", &elMother_energy_MultiLepCalc, &b_elMother_energy_MultiLepCalc);
+   inputTree->SetBranchAddress("elMother_eta_MultiLepCalc", &elMother_eta_MultiLepCalc, &b_elMother_eta_MultiLepCalc);
+   inputTree->SetBranchAddress("elMother_phi_MultiLepCalc", &elMother_phi_MultiLepCalc, &b_elMother_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("elMother_pt_MultiLepCalc", &elMother_pt_MultiLepCalc, &b_elMother_pt_MultiLepCalc);
+   inputTree->SetBranchAddress("elNhIso_MultiLepCalc", &elNhIso_MultiLepCalc, &b_elNhIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elOoemoop_MultiLepCalc", &elOoemoop_MultiLepCalc, &b_elOoemoop_MultiLepCalc);
+   inputTree->SetBranchAddress("elPFEta_MultiLepCalc", &elPFEta_MultiLepCalc, &b_elPFEta_MultiLepCalc);
+   inputTree->SetBranchAddress("elPFPhi_MultiLepCalc", &elPFPhi_MultiLepCalc, &b_elPFPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("elPhIso_MultiLepCalc", &elPhIso_MultiLepCalc, &b_elPhIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elPhiVtx_MultiLepCalc", &elPhiVtx_MultiLepCalc, &b_elPhiVtx_MultiLepCalc);
+   inputTree->SetBranchAddress("elPhi_MultiLepCalc", &elPhi_MultiLepCalc, &b_elPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("elPt_MultiLepCalc", &elPt_MultiLepCalc, &b_elPt_MultiLepCalc);
+   inputTree->SetBranchAddress("elRelIso_MultiLepCalc", &elRelIso_MultiLepCalc, &b_elRelIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elRhoIso_MultiLepCalc", &elRhoIso_MultiLepCalc, &b_elRhoIso_MultiLepCalc);
+   inputTree->SetBranchAddress("elSCE_MultiLepCalc", &elSCE_MultiLepCalc, &b_elSCE_MultiLepCalc);
+   inputTree->SetBranchAddress("elSihih_MultiLepCalc", &elSihih_MultiLepCalc, &b_elSihih_MultiLepCalc);
    inputTree->SetBranchAddress("et_BestCalc", &et_BestCalc, &b_et_BestCalc);
    inputTree->SetBranchAddress("eta_BestCalc", &eta_BestCalc, &b_eta_BestCalc);
-   inputTree->SetBranchAddress("evtWeightsMC_singleLepCalc", &evtWeightsMC_singleLepCalc, &b_evtWeightsMC_singleLepCalc);
-   inputTree->SetBranchAddress("genBSLEnergy_singleLepCalc", &genBSLEnergy_singleLepCalc, &b_genBSLEnergy_singleLepCalc);
-   inputTree->SetBranchAddress("genBSLEta_singleLepCalc", &genBSLEta_singleLepCalc, &b_genBSLEta_singleLepCalc);
-   inputTree->SetBranchAddress("genBSLPhi_singleLepCalc", &genBSLPhi_singleLepCalc, &b_genBSLPhi_singleLepCalc);
-   inputTree->SetBranchAddress("genBSLPt_singleLepCalc", &genBSLPt_singleLepCalc, &b_genBSLPt_singleLepCalc);
-   inputTree->SetBranchAddress("genEnergy_singleLepCalc", &genEnergy_singleLepCalc, &b_genEnergy_singleLepCalc);
-   inputTree->SetBranchAddress("genEta_singleLepCalc", &genEta_singleLepCalc, &b_genEta_singleLepCalc);
-   inputTree->SetBranchAddress("genJetEnergy_singleLepCalc", &genJetEnergy_singleLepCalc, &b_genJetEnergy_singleLepCalc);
-   inputTree->SetBranchAddress("genJetEta_singleLepCalc", &genJetEta_singleLepCalc, &b_genJetEta_singleLepCalc);
-   inputTree->SetBranchAddress("genJetPhi_singleLepCalc", &genJetPhi_singleLepCalc, &b_genJetPhi_singleLepCalc);
-   inputTree->SetBranchAddress("genJetPt_singleLepCalc", &genJetPt_singleLepCalc, &b_genJetPt_singleLepCalc);
-   inputTree->SetBranchAddress("genPhi_singleLepCalc", &genPhi_singleLepCalc, &b_genPhi_singleLepCalc);
-   inputTree->SetBranchAddress("genPt_singleLepCalc", &genPt_singleLepCalc, &b_genPt_singleLepCalc);
+   inputTree->SetBranchAddress("evtWeightsMC_MultiLepCalc", &evtWeightsMC_MultiLepCalc, &b_evtWeightsMC_MultiLepCalc);
+   inputTree->SetBranchAddress("genBSLEnergy_MultiLepCalc", &genBSLEnergy_MultiLepCalc, &b_genBSLEnergy_MultiLepCalc);
+   inputTree->SetBranchAddress("genBSLEta_MultiLepCalc", &genBSLEta_MultiLepCalc, &b_genBSLEta_MultiLepCalc);
+   inputTree->SetBranchAddress("genBSLPhi_MultiLepCalc", &genBSLPhi_MultiLepCalc, &b_genBSLPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("genBSLPt_MultiLepCalc", &genBSLPt_MultiLepCalc, &b_genBSLPt_MultiLepCalc);
+   inputTree->SetBranchAddress("genEnergy_MultiLepCalc", &genEnergy_MultiLepCalc, &b_genEnergy_MultiLepCalc);
+   inputTree->SetBranchAddress("genEta_MultiLepCalc", &genEta_MultiLepCalc, &b_genEta_MultiLepCalc);
+   inputTree->SetBranchAddress("genJetEnergy_MultiLepCalc", &genJetEnergy_MultiLepCalc, &b_genJetEnergy_MultiLepCalc);
+   inputTree->SetBranchAddress("genJetEta_MultiLepCalc", &genJetEta_MultiLepCalc, &b_genJetEta_MultiLepCalc);
+   inputTree->SetBranchAddress("genJetPhi_MultiLepCalc", &genJetPhi_MultiLepCalc, &b_genJetPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("genJetPt_MultiLepCalc", &genJetPt_MultiLepCalc, &b_genJetPt_MultiLepCalc);
+   inputTree->SetBranchAddress("genPhi_MultiLepCalc", &genPhi_MultiLepCalc, &b_genPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("genPt_MultiLepCalc", &genPt_MultiLepCalc, &b_genPt_MultiLepCalc);
    inputTree->SetBranchAddress("isotropyH_BestCalc", &isotropyH_BestCalc, &b_isotropyH_BestCalc);
    inputTree->SetBranchAddress("isotropyW_BestCalc", &isotropyW_BestCalc, &b_isotropyW_BestCalc);
    inputTree->SetBranchAddress("isotropyZ_BestCalc", &isotropyZ_BestCalc, &b_isotropyZ_BestCalc);
@@ -2202,32 +2203,32 @@ void step1::Init(TTree *tree)
    inputTree->SetBranchAddress("m23_jet_BestCalc", &m23_jet_BestCalc, &b_m23_jet_BestCalc);
    inputTree->SetBranchAddress("m23top_BestCalc", &m23top_BestCalc, &b_m23top_BestCalc);
    inputTree->SetBranchAddress("mass_BestCalc", &mass_BestCalc, &b_mass_BestCalc);
-   inputTree->SetBranchAddress("muChIso_singleLepCalc", &muChIso_singleLepCalc, &b_muChIso_singleLepCalc);
-   inputTree->SetBranchAddress("muChi2_singleLepCalc", &muChi2_singleLepCalc, &b_muChi2_singleLepCalc);
-   inputTree->SetBranchAddress("muDxy_singleLepCalc", &muDxy_singleLepCalc, &b_muDxy_singleLepCalc);
-   inputTree->SetBranchAddress("muDz_singleLepCalc", &muDz_singleLepCalc, &b_muDz_singleLepCalc);
-   inputTree->SetBranchAddress("muEnergy_singleLepCalc", &muEnergy_singleLepCalc, &b_muEnergy_singleLepCalc);
-   inputTree->SetBranchAddress("muEta_singleLepCalc", &muEta_singleLepCalc, &b_muEta_singleLepCalc);
-   inputTree->SetBranchAddress("muGIso_singleLepCalc", &muGIso_singleLepCalc, &b_muGIso_singleLepCalc);
-   inputTree->SetBranchAddress("muGen_Reco_dr_singleLepCalc", &muGen_Reco_dr_singleLepCalc, &b_muGen_Reco_dr_singleLepCalc);
-   inputTree->SetBranchAddress("muInnerEta_singleLepCalc", &muInnerEta_singleLepCalc, &b_muInnerEta_singleLepCalc);
-   inputTree->SetBranchAddress("muInnerPhi_singleLepCalc", &muInnerPhi_singleLepCalc, &b_muInnerPhi_singleLepCalc);
-   inputTree->SetBranchAddress("muInnerPt_singleLepCalc", &muInnerPt_singleLepCalc, &b_muInnerPt_singleLepCalc);
-   inputTree->SetBranchAddress("muMatchedEnergy_singleLepCalc", &muMatchedEnergy_singleLepCalc, &b_muMatchedEnergy_singleLepCalc);
-   inputTree->SetBranchAddress("muMatchedEta_singleLepCalc", &muMatchedEta_singleLepCalc, &b_muMatchedEta_singleLepCalc);
-   inputTree->SetBranchAddress("muMatchedPhi_singleLepCalc", &muMatchedPhi_singleLepCalc, &b_muMatchedPhi_singleLepCalc);
-   inputTree->SetBranchAddress("muMatchedPt_singleLepCalc", &muMatchedPt_singleLepCalc, &b_muMatchedPt_singleLepCalc);
-   inputTree->SetBranchAddress("muMiniIsoDB_singleLepCalc", &muMiniIsoDB_singleLepCalc, &b_muMiniIsoDB_singleLepCalc);
-   inputTree->SetBranchAddress("muMiniIso_singleLepCalc", &muMiniIso_singleLepCalc, &b_muMiniIso_singleLepCalc);
-   inputTree->SetBranchAddress("muMother_energy_singleLepCalc", &muMother_energy_singleLepCalc, &b_muMother_energy_singleLepCalc);
-   inputTree->SetBranchAddress("muMother_eta_singleLepCalc", &muMother_eta_singleLepCalc, &b_muMother_eta_singleLepCalc);
-   inputTree->SetBranchAddress("muMother_phi_singleLepCalc", &muMother_phi_singleLepCalc, &b_muMother_phi_singleLepCalc);
-   inputTree->SetBranchAddress("muMother_pt_singleLepCalc", &muMother_pt_singleLepCalc, &b_muMother_pt_singleLepCalc);
-   inputTree->SetBranchAddress("muNhIso_singleLepCalc", &muNhIso_singleLepCalc, &b_muNhIso_singleLepCalc);
-   inputTree->SetBranchAddress("muPhi_singleLepCalc", &muPhi_singleLepCalc, &b_muPhi_singleLepCalc);
-   inputTree->SetBranchAddress("muPt_singleLepCalc", &muPt_singleLepCalc, &b_muPt_singleLepCalc);
-   inputTree->SetBranchAddress("muPuIso_singleLepCalc", &muPuIso_singleLepCalc, &b_muPuIso_singleLepCalc);
-   inputTree->SetBranchAddress("muRelIso_singleLepCalc", &muRelIso_singleLepCalc, &b_muRelIso_singleLepCalc);
+   inputTree->SetBranchAddress("muChIso_MultiLepCalc", &muChIso_MultiLepCalc, &b_muChIso_MultiLepCalc);
+   inputTree->SetBranchAddress("muChi2_MultiLepCalc", &muChi2_MultiLepCalc, &b_muChi2_MultiLepCalc);
+   inputTree->SetBranchAddress("muDxy_MultiLepCalc", &muDxy_MultiLepCalc, &b_muDxy_MultiLepCalc);
+   inputTree->SetBranchAddress("muDz_MultiLepCalc", &muDz_MultiLepCalc, &b_muDz_MultiLepCalc);
+   inputTree->SetBranchAddress("muEnergy_MultiLepCalc", &muEnergy_MultiLepCalc, &b_muEnergy_MultiLepCalc);
+   inputTree->SetBranchAddress("muEta_MultiLepCalc", &muEta_MultiLepCalc, &b_muEta_MultiLepCalc);
+   inputTree->SetBranchAddress("muGIso_MultiLepCalc", &muGIso_MultiLepCalc, &b_muGIso_MultiLepCalc);
+   inputTree->SetBranchAddress("muGen_Reco_dr_MultiLepCalc", &muGen_Reco_dr_MultiLepCalc, &b_muGen_Reco_dr_MultiLepCalc);
+   inputTree->SetBranchAddress("muInnerEta_MultiLepCalc", &muInnerEta_MultiLepCalc, &b_muInnerEta_MultiLepCalc);
+   inputTree->SetBranchAddress("muInnerPhi_MultiLepCalc", &muInnerPhi_MultiLepCalc, &b_muInnerPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("muInnerPt_MultiLepCalc", &muInnerPt_MultiLepCalc, &b_muInnerPt_MultiLepCalc);
+   inputTree->SetBranchAddress("muMatchedEnergy_MultiLepCalc", &muMatchedEnergy_MultiLepCalc, &b_muMatchedEnergy_MultiLepCalc);
+   inputTree->SetBranchAddress("muMatchedEta_MultiLepCalc", &muMatchedEta_MultiLepCalc, &b_muMatchedEta_MultiLepCalc);
+   inputTree->SetBranchAddress("muMatchedPhi_MultiLepCalc", &muMatchedPhi_MultiLepCalc, &b_muMatchedPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("muMatchedPt_MultiLepCalc", &muMatchedPt_MultiLepCalc, &b_muMatchedPt_MultiLepCalc);
+   inputTree->SetBranchAddress("muMiniIsoDB_MultiLepCalc", &muMiniIsoDB_MultiLepCalc, &b_muMiniIsoDB_MultiLepCalc);
+   inputTree->SetBranchAddress("muMiniIso_MultiLepCalc", &muMiniIso_MultiLepCalc, &b_muMiniIso_MultiLepCalc);
+   inputTree->SetBranchAddress("muMother_energy_MultiLepCalc", &muMother_energy_MultiLepCalc, &b_muMother_energy_MultiLepCalc);
+   inputTree->SetBranchAddress("muMother_eta_MultiLepCalc", &muMother_eta_MultiLepCalc, &b_muMother_eta_MultiLepCalc);
+   inputTree->SetBranchAddress("muMother_phi_MultiLepCalc", &muMother_phi_MultiLepCalc, &b_muMother_phi_MultiLepCalc);
+   inputTree->SetBranchAddress("muMother_pt_MultiLepCalc", &muMother_pt_MultiLepCalc, &b_muMother_pt_MultiLepCalc);
+   inputTree->SetBranchAddress("muNhIso_MultiLepCalc", &muNhIso_MultiLepCalc, &b_muNhIso_MultiLepCalc);
+   inputTree->SetBranchAddress("muPhi_MultiLepCalc", &muPhi_MultiLepCalc, &b_muPhi_MultiLepCalc);
+   inputTree->SetBranchAddress("muPt_MultiLepCalc", &muPt_MultiLepCalc, &b_muPt_MultiLepCalc);
+   inputTree->SetBranchAddress("muPuIso_MultiLepCalc", &muPuIso_MultiLepCalc, &b_muPuIso_MultiLepCalc);
+   inputTree->SetBranchAddress("muRelIso_MultiLepCalc", &muRelIso_MultiLepCalc, &b_muRelIso_MultiLepCalc);
    inputTree->SetBranchAddress("pzOverp_H_BestCalc", &pzOverp_H_BestCalc, &b_pzOverp_H_BestCalc);
    inputTree->SetBranchAddress("pzOverp_W_BestCalc", &pzOverp_W_BestCalc, &b_pzOverp_W_BestCalc);
    inputTree->SetBranchAddress("pzOverp_Z_BestCalc", &pzOverp_Z_BestCalc, &b_pzOverp_Z_BestCalc);
@@ -2319,12 +2320,12 @@ void step1::Init(TTree *tree)
    inputTree->SetBranchAddress("topbEta_TTbarMassCalc", &topbEta_TTbarMassCalc, &b_topbEta_TTbarMassCalc);
    inputTree->SetBranchAddress("topbPhi_TTbarMassCalc", &topbPhi_TTbarMassCalc, &b_topbPhi_TTbarMassCalc);
    inputTree->SetBranchAddress("topbPt_TTbarMassCalc", &topbPt_TTbarMassCalc, &b_topbPt_TTbarMassCalc);
-   inputTree->SetBranchAddress("electron_hltfilters_singleLepCalc", &electron_hltfilters_singleLepCalc, &b_electron_hltfilters_singleLepCalc);
-   inputTree->SetBranchAddress("muon_hltfilters_singleLepCalc", &muon_hltfilters_singleLepCalc, &b_muon_hltfilters_singleLepCalc);
-   inputTree->SetBranchAddress("vsSelMCTriggersEl_singleLepCalc", &vsSelMCTriggersEl_singleLepCalc, &b_vsSelMCTriggersEl_singleLepCalc);
-   inputTree->SetBranchAddress("vsSelMCTriggersMu_singleLepCalc", &vsSelMCTriggersMu_singleLepCalc, &b_vsSelMCTriggersMu_singleLepCalc);
-   inputTree->SetBranchAddress("vsSelTriggersEl_singleLepCalc", &vsSelTriggersEl_singleLepCalc, &b_vsSelTriggersEl_singleLepCalc);
-   inputTree->SetBranchAddress("vsSelTriggersMu_singleLepCalc", &vsSelTriggersMu_singleLepCalc, &b_vsSelTriggersMu_singleLepCalc);
+   inputTree->SetBranchAddress("electron_hltfilters_MultiLepCalc", &electron_hltfilters_MultiLepCalc, &b_electron_hltfilters_MultiLepCalc);
+   inputTree->SetBranchAddress("muon_hltfilters_MultiLepCalc", &muon_hltfilters_MultiLepCalc, &b_muon_hltfilters_MultiLepCalc);
+   inputTree->SetBranchAddress("vsSelMCTriggersEl_MultiLepCalc", &vsSelMCTriggersEl_MultiLepCalc, &b_vsSelMCTriggersEl_MultiLepCalc);
+   inputTree->SetBranchAddress("vsSelMCTriggersMu_MultiLepCalc", &vsSelMCTriggersMu_MultiLepCalc, &b_vsSelMCTriggersMu_MultiLepCalc);
+   inputTree->SetBranchAddress("vsSelTriggersEl_MultiLepCalc", &vsSelTriggersEl_MultiLepCalc, &b_vsSelTriggersEl_MultiLepCalc);
+   inputTree->SetBranchAddress("vsSelTriggersMu_MultiLepCalc", &vsSelTriggersMu_MultiLepCalc, &b_vsSelTriggersMu_MultiLepCalc);
    Notify();
 }
 

--- a/step1/step1.h
+++ b/step1/step1.h
@@ -1294,7 +1294,10 @@ step1::step1(TString inputFileName, TString outputFileName) : inputTree(0), inpu
   isTTincMtt1000toInf = outputFileName.Contains("Mtt1000toInf");
 
   std::cout<<"Opening file: "<<inputFileName<<std::endl;
-  inputFile=TFile::Open(inputFileName);
+  if(!(inputFile=TFile::Open(inputFileName))){
+    std::cout<<"WARNING! File doesn't exist! Exiting" << std::endl;
+    exit(1);
+  }
 //  inputTree=(TTree*)inputFile->Get("ljmet/ljmet");
 //  if(inputTree->GetEntries()==0) std::cout<<"WARNING! Found 0 events in the tree!!!!"<<std::endl;;
   

--- a/step1/testStep1.C
+++ b/step1/testStep1.C
@@ -15,8 +15,8 @@ void testStep1(){
 
   vector<TString> shifts = { "ljmet", "ljmet_JECup", "ljmet_JECdown", "ljmet_JERup", "ljmet_JERdown" };
   for (size_t i =0; i<shifts.size(); ++i) {
-  cout << endl << "Running shift " << shifts[i] << endl;
-  t.Loop(shifts[i], shifts[i]);
+    cout << endl << "Running shift " << shifts[i] << endl;
+    t.Loop(shifts[i], shifts[i]);
 }
 
 }

--- a/step1/testStep1.C
+++ b/step1/testStep1.C
@@ -1,16 +1,24 @@
 #include "step1.cc"
+#include<vector>
+using namespace std;
 
 void testStep1(){
   
-  //TString inputFile="root://cmseos.fnal.gov//store/user/lpcljm/2018/LJMet94X_1lepTT_091518/nominal/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8/TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8_99.root";
-  //TString inputFile="root://cmseos.fnal.gov//store/user/lpcljm/Mary_4Tops_Third_Real_Run_23Jan19_22h00Cern/nominal/4T_17_MC_Signal_List/4T_17_MC_Signal_List_2.root";
-  TString inputFile="root://cmseos.fnal.gov//store/user/lpcljm/2018/LJMet94X_1lepTT_091518/nominal/TTTT_TuneCP5_13TeV-amcatnlo-pythia8/TTTT_TuneCP5_13TeV-amcatnlo-pythia8_12.root";
+ //TString inputFile="root://cmsxrootd.fnal.gov//store/user/lpcljm/FWLJMET_crab_TTTT_singlelep_May092019_wenyu/TTToSemiLepton_HT500Njet9_TuneCP5_PSweights_13TeV-powheg-pythia8/crab_FWLJMET_TTTT_May092019_wenyu/190509_182010/0000/TTTT_TuneCP5_PSweights_13TeV-amcatnlo-pythia8_FWLJMET_MC_1.root";
+  TString inputFile="root://cmseos.fnal.gov//store/user/lpcljm/FWLJMET102X_1lep2017_052219/TTToSemiLepton_HT500Njet9_TuneCP5_PSweights_13TeV-powheg-pythia8/singleLep2017/190610_195506/0000/TTToSemiLepton_HT500Njet9_TuneCP5_PSweights_13TeV-powheg-pythia8_10.root" ;
   TString outputFile="test.root";
   
   gSystem->AddIncludePath("-I$CMSSW_BASE/src/");
   
   step1 t(inputFile,outputFile);
-  t.Loop();
+  t.saveHistograms();
+
+  vector<TString> shifts = { "ljmet", "ljmet_JECup", "ljmet_JECdown", "ljmet_JERup", "ljmet_JERdown" };
+  for (size_t i =0; i<shifts.size(); ++i) {
+  cout << endl << "Running shift " << shifts[i] << endl;
+  t.Loop(shifts[i], shifts[i]);
+}
+
 }
 
 

--- a/step1/testStep1.C
+++ b/step1/testStep1.C
@@ -5,20 +5,25 @@ using namespace std;
 void testStep1(){
   
  //TString inputFile="root://cmsxrootd.fnal.gov//store/user/lpcljm/FWLJMET_crab_TTTT_singlelep_May092019_wenyu/TTToSemiLepton_HT500Njet9_TuneCP5_PSweights_13TeV-powheg-pythia8/crab_FWLJMET_TTTT_May092019_wenyu/190509_182010/0000/TTTT_TuneCP5_PSweights_13TeV-amcatnlo-pythia8_FWLJMET_MC_1.root";
-  TString inputFile="root://cmseos.fnal.gov//store/user/lpcljm/FWLJMET102X_1lep2017_052219/TTToSemiLepton_HT500Njet9_TuneCP5_PSweights_13TeV-powheg-pythia8/singleLep2017/190610_195506/0000/TTToSemiLepton_HT500Njet9_TuneCP5_PSweights_13TeV-powheg-pythia8_10.root" ;
+//  TString inputFile="root://cmseos.fnal.gov//store/user/lpcljm/FWLJMET102X_1lep2017_052219/TTToSemiLepton_HT500Njet9_TuneCP5_PSweights_13TeV-powheg-pythia8/singleLep2017/190610_195506/0000/TTToSemiLepton_HT500Njet9_TuneCP5_PSweights_13TeV-powheg-pythia8_10.root" ;
+  TString inputFile="root://cmseos.fnal.gov//store/user/lpcljm/FWLJMET102X_1lep2017_052219/SingleElectron/singleLep2017/190610_165959/0000/SingleElectronRun2017C_1-27.root" ;
   TString outputFile="test.root";
   
   gSystem->AddIncludePath("-I$CMSSW_BASE/src/");
   
   step1 t(inputFile,outputFile);
-  t.saveHistograms();
+  
+  if ( inputFile.Contains("Run2017") ) 
+    { t.Loop("ljmet", "ljmet"); }
 
-  vector<TString> shifts = { "ljmet", "ljmet_JECup", "ljmet_JECdown", "ljmet_JERup", "ljmet_JERdown" };
-  for (size_t i =0; i<shifts.size(); ++i) {
-    cout << endl << "Running shift " << shifts[i] << endl;
-    t.Loop(shifts[i], shifts[i]);
-}
-
+  else {
+    t.saveHistograms();
+    vector<TString> shifts = { "ljmet", "ljmet_JECup", "ljmet_JECdown", "ljmet_JERup", "ljmet_JERdown" };
+    for (size_t i =0; i<shifts.size(); ++i) {
+      cout << endl << "Running shift " << shifts[i] << endl;
+      t.Loop(shifts[i], shifts[i]);
+    }
+  }
 }
 
 


### PR DESCRIPTION
step1.h/.cc. : modified Calc name to MultiLepCalc, removed elMVAValue, edited Loop() function to see arguments of input tree name and output tree name.  Save histograms from ljmet files. 
testStep1.C (makeStep1.C): accommodate 5 shifts of ljmet for MC, but just one ljmet tree for data. 
runCondorSlimmerJobs2017.py: path of inputfiles; separate MC, special MC with ext, and data, using different input path and output file name.