### PR TITLE
Added new xSFs, slSFs and hadSFs ; and made an additional minDR for jets

### DIFF
--- a/step1/HardcodedConditions.cc
+++ b/step1/HardcodedConditions.cc
@@ -2603,53 +2603,242 @@ double HardcodedConditions::GetElectronIsoSF2018(double pt, double eta)
   \     /                                                       \     /
    `---'                                                         `---'*/
 
-double HardcodedConditions::GetElectronTriggerSF(double pt, double ht, int year)
+double HardcodedConditions::GetElectronTriggerSF(double pt, double eta, int year)
 {
   //The main getter for Electron Trigger Scale Factors
-  if      (year==2016) return GetElectronTriggerSF2016(pt, ht);
-  else if (year==2017) return GetElectronTriggerSF2017(pt, ht);
-  else if (year==2018) return GetElectronTriggerSF2018(pt, ht);
+  if      (year==2016) return GetElectronTriggerSF2016(pt, eta);
+  else if (year==2017) return GetElectronTriggerSF2017(pt, eta);
+  else if (year==2018) return GetElectronTriggerSF2018(pt, eta);
   else return 0.;
 }//end GetElectronTriggerSF
 
-double HardcodedConditions::GetElectronTriggerSF2016(double pt, double ht)
+double HardcodedConditions::GetElectronTriggerSF2016(double pt, double eta)
 {
 	// TO-BE-IMPLEMENTED!!!!!!!
 	return 1.000;
 
 }
 
-double HardcodedConditions::GetElectronTriggerSF2017(double pt, double ht)
+double HardcodedConditions::GetElectronTriggerSF2017(double pt, double eta)
 {
 	// Trigger Scale Factors, SF2017B_Bkg_LepPtEta_EOR.png & SF2017CDEF_Bkg_LepPtEta_EOR.png
 	float triggerSFB = 1.0;
 	float triggerSFC = 1.0;
 	float triggerSFDEF = 1.0;
-	if (ht > 500.0 && ht < 750.0){
+	float triggerSFBunc = 0.0;
+	float triggerSFCunc = 0.0;
+	float triggerSFDEFunc = 0.0;
+
+	if (eta > 0.0 && eta <= 0.8){
+	    if(pt >30.0 && pt <= 35.0){triggerSFDEF=0.910508894879; triggerSFDEFunc=0.0252630974566; }
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFB=1.19235377821; triggerSFBunc=0.00972352951004; triggerSFC=0.961432584122; triggerSFCunc=0.0206050210328;triggerSFDEF=0.953531146324; triggerSFDEFunc=0.00966443825252;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFB=1.15582596391; triggerSFBunc=0.0101490597149; triggerSFC=0.957629044796; triggerSFCunc=0.0156301400464;triggerSFDEF=0.969037828674; triggerSFDEFunc=0.00902253599794;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFB=1.14242389742; triggerSFBunc=0.00549159903045; triggerSFC=0.952084569431; triggerSFCunc=0.0156343831136;triggerSFDEF=0.972670135935; triggerSFDEFunc=0.00874302598399;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.13798058665; triggerSFBunc=0.00440646655911; triggerSFC=0.972836208578; triggerSFCunc=0.0109869570181;triggerSFDEF=0.97354484058; triggerSFDEFunc=0.00662049424611;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.11927898325; triggerSFBunc=0.00270996230892; triggerSFC=0.97878084945; triggerSFCunc=0.00639206054071;triggerSFDEF=0.978742705794; triggerSFDEFunc=0.00393049250046;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.08208421955; triggerSFBunc=0.00263577695243;triggerSFC=0.97205414899; triggerSFCunc=0.00666655373504;triggerSFDEF=0.976656543342; triggerSFDEFunc=0.00402836298722;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.05681427994; triggerSFBunc=0.00197390294288;triggerSFC=0.988668281842; triggerSFCunc=0.0108354482413;triggerSFDEF=0.980285171661; triggerSFDEFunc=0.00719412375919;}
+	}
+	else if (eta > 0.8 && eta <= 1.442){
+	    if(pt >30.0 && pt <= 35.0){triggerSFDEF=0.751761888491; triggerSFDEFunc=0.0392563144486;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFB=1.15822014397; triggerSFBunc=0.0366899788708; triggerSFC=0.860499625902; triggerSFCunc=0.0338474227491;triggerSFDEF=0.919657299703; triggerSFDEFunc=0.0145884627614;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFB=1.21616929374; triggerSFBunc=0.0075355308975; triggerSFC=0.954195822579; triggerSFCunc=0.0216774946301;triggerSFDEF=0.9416298044; triggerSFDEFunc=0.0135284523691;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFB=1.17221728706; triggerSFBunc=0.00598476735072;triggerSFC=0.95883629846; triggerSFCunc=0.0208809133241; triggerSFDEF=0.967038221562; triggerSFDEFunc=0.012176898146;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.19498750549; triggerSFBunc=0.0178876420601; triggerSFC=0.954662162504; triggerSFCunc=0.0160626737532;triggerSFDEF=0.975886529118; triggerSFDEFunc=0.00901597488231;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.14500756907; triggerSFBunc=0.00769191207143; triggerSFC=0.973404630486; triggerSFCunc=0.00863116494001;triggerSFDEF=0.981893775663; triggerSFDEFunc=0.00516090030148;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.08473672928; triggerSFBunc=0.00377953565311;triggerSFC=0.982716650785; triggerSFCunc=0.00847325191329;triggerSFDEF=0.978950786067; triggerSFDEFunc=0.0052715751246;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.04804436988; triggerSFBunc=0.00275314759171;triggerSFC=0.962029353635; triggerSFCunc=0.0169198961547; triggerSFDEF=0.979265291494; triggerSFDEFunc=0.0093553710705;}
+	}
+	else if (eta > 1.442 && eta <= 2.0){
+	    if(pt >30.0 && pt <= 35.0){triggerSFDEF=0.61359340781; triggerSFDEFunc=0.0720651614296; }
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFB=0.979837673172; triggerSFBunc=0.0996061772208;triggerSFC=0.834393494481; triggerSFCunc=0.0545242814001;triggerSFDEF=0.865218488115; triggerSFDEFunc=0.0255203774749;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFB=1.09592474113; triggerSFBunc=0.0388939927352; triggerSFC=0.934846351249; triggerSFCunc=0.0336441519287; triggerSFDEF=0.92564191376; triggerSFDEFunc=0.0228158658932; }
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFB=1.14329944654; triggerSFBunc=0.0390830761738; triggerSFC=0.962071721753; triggerSFCunc=0.0323504865487;triggerSFDEF=0.910259293332; triggerSFDEFunc=0.023206491402; }
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.12458617216; triggerSFBunc=0.0207787584607; triggerSFC=0.939378108547; triggerSFCunc=0.0246293245522; triggerSFDEF=0.951179859384; triggerSFDEFunc=0.0150226105676;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.12172511077; triggerSFBunc=0.0220454574283; triggerSFC=0.987642127321; triggerSFCunc=0.0210337676182; triggerSFDEF=0.968589861037; triggerSFDEFunc=0.0173841185589;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.09052141074; triggerSFBunc=0.0140524818938; triggerSFC=0.985970344843; triggerSFCunc=0.0167420341634; triggerSFDEF=0.967442726925; triggerSFDEFunc=0.0115473116236;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.08883369326; triggerSFBunc=0.0193992275579;  triggerSFC=0.893843409369; triggerSFCunc=0.0558133858133; triggerSFDEF=0.958624277634; triggerSFDEFunc=0.0308831433403;}
+	}
+	else if (eta > 2.0 && eta <= 2.4){
+	    if(pt >30.0 && pt <= 35.0){triggerSFDEF=1.34938101512; triggerSFDEFunc=0.897934586653;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFB=0.852743087035; triggerSFBunc=0.177423039542;triggerSFC=0.682868604737; triggerSFCunc=0.144437037161; triggerSFDEF=0.809342108762; triggerSFDEFunc=0.0630935824021;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFB=1.1679917664; triggerSFBunc=0.0167310627084; triggerSFC=1.0519398793; triggerSFCunc=0.0583624743679; triggerSFDEF=0.929952818205; triggerSFDEFunc=0.0555593489689;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFB=1.19320302369; triggerSFBunc=0.0205220242409;triggerSFC=0.983854619602; triggerSFCunc=0.0710158704718;triggerSFDEF=0.996331036879; triggerSFDEFunc=0.0509581507824;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.08557256937; triggerSFBunc=0.117006664089; triggerSFC=0.996753585332; triggerSFCunc=0.0684326387008;triggerSFDEF=0.926442474712; triggerSFDEFunc=0.0458155559586;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.18448651178; triggerSFBunc=0.0697531410082;triggerSFC=1.02919877827; triggerSFCunc=0.0716198040658; triggerSFDEF=1.03147014466; triggerSFDEFunc=0.058149906159;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.06393762562; triggerSFBunc=0.0624111781463;triggerSFC=1.01898572985; triggerSFCunc=0.0416570105471;triggerSFDEF=0.976709670734; triggerSFDEFunc=0.0321444698532;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.07201980973; triggerSFBunc=0.0236270951373;triggerSFC=1.06465564707; triggerSFCunc=0.0231736721195;triggerSFDEF=0.958190082361; triggerSFDEFunc=0.103132973757; }
+	}
+
+
+	/*if (ht > 500.0 && ht < 750.0){
 	  if (pt > 20.0 && pt < 50.0){triggerSFB = 0.907;triggerSFC = 0.931;triggerSFDEF = 0.967;}
 	  else if (pt >=50.0 && pt <= 300.0){triggerSFB = 0.997;triggerSFC = 0.999;triggerSFDEF = 0.999;}
 	}
 	else if (ht >= 750.0 && ht < 3000.0){
 	    if (pt > 20.0 && pt < 50.0){triggerSFB = 0.888;triggerSFC = 0.923;triggerSFDEF = 0.963;}
 	    else if (pt >=50.0 && pt <= 300.0){triggerSFB = 0.996;triggerSFC = 1.000;triggerSFDEF = 0.999;}
-	}
+	}*/
 	return (4.823*triggerSFB+ 9.664*triggerSFC + 27.07*triggerSFDEF)/41.557;
 
 }
 
-double HardcodedConditions::GetElectronTriggerSF2018(double pt, double ht)
+double HardcodedConditions::GetElectronTriggerSF2018(double pt, double eta)
 {
-  float triggerSFAB = 1.0;
-  float triggerSFCD = 1.0;
-  if (ht > 500.0 && ht < 750.0){
+  float triggerSFABCD = 1.0;
+  float triggerSFABCDunc = 0.0;
+  if (eta > 0.0 && eta <= 0.8){
+	    if(pt >30.0 && pt <= 35.0){triggerSFABCD=0.913692057441; triggerSFABCDunc=0.0154464370968;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFABCD=0.971695502732; triggerSFABCDunc=0.00613023548779;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFABCD=0.973472902604; triggerSFABCDunc=0.00581754877102;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFABCD=0.975870251002; triggerSFABCDunc=0.00591952371387;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFABCD=0.972260692149; triggerSFABCDunc=0.00426073436109;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFABCD=0.978462954775; triggerSFABCDunc=0.00251528166842;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFABCD=0.982340801275; triggerSFABCDunc=0.00249892269699;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFABCD=0.988277803553; triggerSFABCDunc=0.00408553511306;}
+	}
+	else if (eta > 0.8 && eta <= 1.442){
+	    if(pt >30.0 && pt <= 35.0){triggerSFABCD=0.79130810157; triggerSFABCDunc=0.0257604488845;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFABCD=0.95794335208; triggerSFABCDunc=0.0200823014694;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFABCD=0.98584588097; triggerSFABCDunc=0.0077862661467;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFABCD=0.986921685202; triggerSFABCDunc=0.0127837800598; }
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFABCD=1.01257881296; triggerSFABCDunc=0.0160565199922;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFABCD=0.985749736854; triggerSFABCDunc=0.00366472974788;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFABCD=0.993225266785; triggerSFABCDunc=0.00626714108618;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFABCD=1.0017169042; triggerSFABCDunc=0.00833637183928;}
+	}
+	else if (eta > 1.442 && eta <= 2.0){
+	    if(pt >30.0 && pt <= 35.0){triggerSFABCD=0.784488053273; triggerSFABCDunc=0.0399543285185;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFABCD=0.923642602884; triggerSFABCDunc=0.0250525652842;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFABCD=0.949818783052; triggerSFABCDunc=0.0160756054522;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFABCD=0.994631635079; triggerSFABCDunc=0.0190307120158;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFABCD=0.971684494245; triggerSFABCDunc=0.0170379153418;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFABCD=0.975080347642; triggerSFABCDunc=0.00914101473342;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFABCD=0.945571234252; triggerSFABCDunc=0.00842362907735;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFABCD=0.917539801421; triggerSFABCDunc=0.0223619496622;}
+	}
+	else if (eta > 2.0 && eta <= 2.4){
+	    if(pt >30.0 && pt <= 35.0){triggerSFABCD=0.771792545521; triggerSFABCDunc=0.0822918878152;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFABCD=0.877438998912; triggerSFABCDunc=0.035306995628;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFABCD=1.05068262187; triggerSFABCDunc=0.0582042341467;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFABCD=0.963750775537; triggerSFABCDunc=0.0331998840585;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFABCD=0.944876225901; triggerSFABCDunc=0.0237164780054;}
+	    else if(pt > 60.0 && pt >= 100.0){ triggerSFABCD=0.954494360964; triggerSFABCDunc=0.0153518496535;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFABCD=0.940644961626; triggerSFABCDunc=0.0308095483653;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFABCD=0.795593538315; triggerSFABCDunc=0.0538805201514;}
+	}
+  /*if (ht > 500.0 && ht < 750.0){
     if (pt > 20.0 && pt < 50.0){triggerSFAB = 0.970;triggerSFCD = 0.981;}
     else if (pt >=50.0 && pt <= 300.0){triggerSFAB = 0.999;triggerSFCD = 1.000;}
   }
   else if (ht >= 750.0 && ht < 3000.0){
     if (pt > 20.0 && pt < 50.0){triggerSFAB = 0.959;triggerSFCD = 0.990;}
     else if (pt >=50.0 && pt <= 300.0){triggerSFAB = 0.998;triggerSFCD = 0.999;}
-  }
-  return (21.10*triggerSFAB+ 38.87*triggerSFCD)/59.97;
+  }*/
+  return triggerSFABCD;
+}
+
+/*.-----------------------------------------------------------------.
+  /  .-.                                                         .-.  \
+ |  /   \                                                       /   \  |
+ | |\_.  |                                                     |    /| |
+ |\|  | /|         HADRON TRIGGER SCALE FACTOR SECTION         |\  | |/|
+ | `---' |               (For Electron Channel)                | `---' |
+ |       |                                                     |       |
+ |       |-----------------------------------------------------|       |
+ \       |                                                     |       /
+  \     /                                                       \     /
+   `---'                                                         `---'*/
+
+double HardcodedConditions::GetIsEHadronTriggerSF(double njets, double ht, int year)
+{
+  //The main getter for Electron Trigger Scale Factors
+  if      (year==2016) return GetIsEHadronTriggerSF2016(njets, ht);
+  else if (year==2017) return GetIsEHadronTriggerSF2017(njets, ht);
+  else if (year==2018) return GetIsEHadronTriggerSF2018(njets, ht);
+  else return 0.;
+}//end GetElectronTriggerSF
+
+double HardcodedConditions::GetIsEHadronTriggerSF2016(double njets, double ht)
+{
+	// TO-BE-IMPLEMENTED!!!!!!!
+	return 1.000;
+
+}
+
+double HardcodedConditions::GetIsEHadronTriggerSF2017(double njets, double ht)
+{
+	// Trigger Scale Factors, SF2017B_Bkg_LepPtEta_EOR.png & SF2017CDEF_Bkg_LepPtEta_EOR.png
+	float triggerSFB = 1.0;
+	float triggerSFC = 1.0;
+	float triggerSFDEF = 1.0;
+	float triggerSFBunc = 0.0;
+	float triggerSFCunc = 0.0;
+	float triggerSFDEFunc = 0.0;
+	if (njets == 6){
+	    if(ht > 500.0 && ht < 675.0){triggerSFB=0.7131034814; triggerSFBunc=0.039195159067;triggerSFC=1.06442916822; triggerSFCunc=0.0191310183113;triggerSFDEF=0.983282002779; triggerSFDEFunc=0.010945804749;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFB=0.685182848626; triggerSFBunc=0.0550213486042;triggerSFC=0.933509202021; triggerSFCunc=0.0319571469815;triggerSFDEF=0.983282002779; triggerSFDEFunc=0.010945804749;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFB=0.703597186532; triggerSFBunc=0.0769206267945;triggerSFC=0.874125512276; triggerSFCunc=0.0491865692362; triggerSFDEF=0.951081570599; triggerSFDEFunc=0.0240807046522;}
+	    else if(ht > 1025.0 ){triggerSFB=0.579846773226; triggerSFBunc=0.0975503616381;triggerSFC=0.884721020286; triggerSFCunc=0.0576515836494;triggerSFDEF=0.93196872246; triggerSFDEFunc=0.0290876876954;}
+	}
+	else if (njets == 7){
+	    if(ht > 500.0 && ht < 675.0){triggerSFB=0.714231771966; triggerSFBunc=0.0460677631312; triggerSFC=1.04926653189; triggerSFCunc=0.0225797076839;triggerSFDEF=0.975633819631; triggerSFDEFunc=0.0133871357773;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFB=0.74233748692; triggerSFBunc=0.0586519596923;triggerSFC=1.02591177026; triggerSFCunc=0.0304834579974;triggerSFDEF=0.973476673028; triggerSFDEFunc=0.016479213933;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFB=0.773750907604; triggerSFBunc=0.0760274269242;triggerSFC=0.968495646173; triggerSFCunc=0.043898355643;triggerSFDEF=0.943797434532; triggerSFDEFunc=0.0245958881885;}
+	    else if(ht > 1025.0 ){triggerSFB=0.605305982369; triggerSFBunc=0.0708403379341;triggerSFC=0.884721020286; triggerSFCunc=0.0576515836494;triggerSFDEF=0.922137473976; triggerSFDEFunc=0.0268627574623;}
+	}
+	else if (njets == 8){
+	    if(ht > 500.0 && ht < 675.0){triggerSFB=0.868823440272; triggerSFBunc=0.0687865318818;triggerSFC=1.04680148615; triggerSFCunc=0.0398178950336;triggerSFDEF=1.00682464403; triggerSFDEFunc=0.0206251589061;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFB=0.748859059586; triggerSFBunc=0.0719696975787;triggerSFC=0.998869999542; triggerSFCunc=0.042632745896;triggerSFDEF=1.00934080574; triggerSFDEFunc=0.0214975217054;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFB=0.716921132745; triggerSFBunc=0.102970006749;triggerSFC=1.07367474404; triggerSFCunc=0.0508483052736;triggerSFDEF=0.98914773359; triggerSFDEFunc=0.0294991158576;}
+	    else if(ht > 1025.0 ){triggerSFB=0.929517173615; triggerSFBunc=0.0875474821156;triggerSFC=0.778086332171; triggerSFCunc=0.0613585387112;triggerSFDEF=0.97651228934; triggerSFDEFunc=0.0286692152279; }
+	}
+	else if (njets >= 9){
+	    if(ht > 500.0 && ht < 675.0){triggerSFB=0.719549247523; triggerSFBunc=0.145657165847;triggerSFC=1.08558687247; triggerSFCunc=0.0722757558896;triggerSFDEF=1.10004232982; triggerSFDEFunc=0.0330874214131;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFB=0.820454121314; triggerSFBunc=0.115674062744;triggerSFC=1.01446464003; triggerSFCunc=0.0586710035419;triggerSFDEF=0.926273529637; triggerSFDEFunc=0.037549725576;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFB=0.752958758053; triggerSFBunc=0.125944437336;triggerSFC=0.873179063961; triggerSFCunc=0.0790579410256;triggerSFDEF=0.96662076276; triggerSFDEFunc=0.0350181506312;}
+	    else if(ht > 1025.0 ){triggerSFB=0.455386650193; triggerSFBunc=0.0929742397607;triggerSFC=0.824568420102; triggerSFCunc=0.0630836384892; triggerSFDEF=0.979846128538; triggerSFDEFunc=0.0282249900232; }
+	}
+    float triggerSFUncert = sqrt( pow(4.823*triggerSFBunc/41.557,2) + pow(9.664*triggerSFCunc/41.557,2) + pow(27.07*triggerSFDEFunc/41.557,2) );
+    float triggerSF = (4.823*triggerSFB+ 9.664*triggerSFC + 27.07*triggerSFDEF)/41.557;
+	return triggerSF;
+
+}
+
+double HardcodedConditions::GetIsEHadronTriggerSF2018(double njets, double ht)
+{
+  float triggerSFAB = 1.0;
+  float triggerSFCD = 1.0;
+  float triggerSFABunc = 0.0;
+  float triggerSFCDunc = 0.0;
+  	if (njets == 6){
+	    if(ht > 500.0 && ht < 675.0){triggerSFAB=0.968206089897; triggerSFABunc=0.0106829897362;triggerSFCD=0.977498593923; triggerSFCDunc=0.00724064739296;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFAB=0.914475149322; triggerSFABunc=0.0158449037699;triggerSFCD=0.945512917623; triggerSFCDunc=0.01076706752;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFAB=0.8484487443; triggerSFABunc=0.0252864251284;triggerSFCD=0.916218285147; triggerSFCDunc=0.0166078728847;}
+	    else if(ht > 1025.0 ){triggerSFAB=0.818129424017; triggerSFABunc=0.0295842407636;triggerSFCD=0.939086980165; triggerSFCDunc=0.0195738591402;}
+	}
+	else if (njets == 7){
+	    if(ht > 500.0 && ht < 675.0){triggerSFAB=1.01435872808; triggerSFABunc=0.0136379664791;triggerSFCD=1.00499926004; triggerSFCDunc=0.00952767390448;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFAB=0.91466472422; triggerSFABunc=0.0185173799717; triggerSFCD=0.955491528449; triggerSFCDunc=0.0121519124267;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFAB=0.968666143174; triggerSFABunc=0.0256979612464;triggerSFCD=0.974986701913; triggerSFCDunc=0.0177384315466;}
+	    else if(ht > 1025.0 ){triggerSFAB=0.980046623746; triggerSFABunc=0.0280524922159;triggerSFCD=0.926004632606; triggerSFCDunc=0.0210110167572;}
+	}
+	else if (njets == 8){
+	    if(ht > 500.0 && ht < 675.0){triggerSFAB=0.936955128853; triggerSFABunc=0.0254944260805;triggerSFCD=1.02490624383; triggerSFCDunc=0.015907478007;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFAB=0.955910518012; triggerSFABunc=0.0279235614579;triggerSFCD=0.984275349326; triggerSFCDunc=0.0193980004758;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFAB=0.972082585397; triggerSFABunc=0.0356773916792;triggerSFCD=1.02092784075; triggerSFCDunc=0.0225048536722;}
+	    else if(ht > 1025.0 ){triggerSFAB=0.916637786296; triggerSFABunc=0.036359451647;triggerSFCD=0.96864371249; triggerSFCDunc=0.0236041629142;}
+
+	}
+	else if (njets >= 9){
+	    if(ht > 500.0 && ht < 675.0){triggerSFAB=1.01413203446; triggerSFABunc=0.0464563918487;triggerSFCD=0.95110722084; triggerSFCDunc=0.0331533447237;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFAB=0.970133496757; triggerSFABunc=0.0368586768362;triggerSFCD=0.996098288346; triggerSFCDunc=0.0253552087868;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFAB=0.942926718587; triggerSFABunc=0.0445291095114;triggerSFCD=0.991907263195; triggerSFCDunc=0.028699822645;}
+	    else if(ht > 1025.0 ){triggerSFAB=0.931569605971; triggerSFABunc=0.0348688784615;triggerSFCD=0.942471490068; triggerSFCDunc=0.0255418143576;}
+	}
+  float triggerSFUncert = sqrt( pow(21.10*triggerSFABunc/59.97,2) + pow(38.87*triggerSFCDunc/59.97,2) );
+  float triggerSF = (21.10*triggerSFAB+ 38.87*triggerSFCD)/59.97;
+  return triggerSF;
 }
 
 
@@ -3038,12 +3227,12 @@ double HardcodedConditions::GetMuonIsoSF2018(double pt, double eta)
   \     /                                                       \     /
    `---'                                                         `---'*/
 
-double HardcodedConditions::GetMuonTriggerSF(double pt, double ht, int year)
+double HardcodedConditions::GetMuonTriggerSF(double pt, double eta, int year)
 {
   //The main getter for Muon Trigger Scale Factors
-  if      (year==2016) return GetMuonTriggerSF2016(pt, ht);
-  else if (year==2017) return GetMuonTriggerSF2017(pt, ht);
-  else if (year==2018) return GetMuonTriggerSF2018(pt, ht);
+  if      (year==2016) return GetMuonTriggerSF2016(pt, eta);
+  else if (year==2017) return GetMuonTriggerSF2017(pt, eta);
+  else if (year==2018) return GetMuonTriggerSF2018(pt, eta);
   else return 0.;
 }//end GetMuonTriggerSF
 
@@ -3054,37 +3243,232 @@ double HardcodedConditions::GetMuonTriggerSF2016(double pt, double eta)
 
 }
 
-double HardcodedConditions::GetMuonTriggerSF2017(double pt, double ht)
+double HardcodedConditions::GetMuonTriggerSF2017(double pt, double eta)
 {
 	float triggerSFB = 1.0;
-	float triggerSFC = 1.0;
-	float triggerSFDEF = 1.0;
-	if (ht > 500.0 && ht < 750.0){
+	float triggerSFCDEF = 1.0;
+	float triggerSFBunc = 0.0;
+	float triggerSFCDEFunc = 0.0;
+	if (eta > 0.0 && eta <= 0.8){
+	    if(pt >30.0 && pt <= 35.0){triggerSFB=1.10019349994; triggerSFBunc=0.00547206712151;triggerSFCDEF=0.978804954631; triggerSFCDEFunc=0.00648538520448;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFB=1.09211088948; triggerSFBunc=0.00204401887493;triggerSFCDEF=0.984698671039; triggerSFCDEFunc=0.00602193913522;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFB=1.07808450861; triggerSFBunc=0.00464941695873;triggerSFCDEF=0.995559844257; triggerSFCDEFunc=0.00567940378055;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFB=1.07193586473; triggerSFBunc=0.00391132533692;triggerSFCDEF=0.988591733802; triggerSFCDEFunc=0.00579494608742;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.01367573178; triggerSFBunc=0.00984912438091;triggerSFCDEF=0.990844343111; triggerSFCDEFunc=0.00401810293322;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.02371459077; triggerSFBunc=0.00453347155488;triggerSFCDEF=0.9899251109; triggerSFCDEFunc=0.00222019796691;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.01917413639; triggerSFBunc=0.00428822026176;triggerSFCDEF=0.989816219066; triggerSFCDEFunc=0.00213658604325;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.03021004051; triggerSFBunc=0.0047931519218;triggerSFCDEF=0.993698209245; triggerSFCDEFunc=0.00407479066069;}
+	}
+    else if (eta > 0.8 && eta <= 1.442){
+	    if(pt >30.0 && pt <= 35.0){triggerSFB=1.12077327256; triggerSFBunc=0.0113246985811;triggerSFCDEF=0.965099847017; triggerSFCDEFunc=0.00969574453469;}
+	    else if(pt > 35.0 && pt <=40.0){triggerSFB=1.11606710619; triggerSFBunc=0.00305398442218;triggerSFCDEF=0.974018899838; triggerSFCDEFunc=0.00871241069532;}
+	    else if(pt >40.0 && pt<=45.0){triggerSFB=1.10646659029; triggerSFBunc=0.00302169373442;triggerSFCDEF=1.00039705989; triggerSFCDEFunc=0.00799929230775;}
+	    else if(pt >45.0 && pt <=50.0){triggerSFB=1.08923843408; triggerSFBunc=0.00285057860769;triggerSFCDEF=0.979438599873; triggerSFCDEFunc=0.00829713158194;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.0428344034; triggerSFBunc=0.0107394273425;triggerSFCDEF=0.987897428252; triggerSFCDEFunc=0.0057226921376;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.04106960725; triggerSFBunc=0.00590548911614;triggerSFCDEF=0.984113306672; triggerSFCDEFunc=0.00341488478406;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.03213107411; triggerSFBunc=0.00600579292185;triggerSFCDEF=0.976053564253; triggerSFCDEFunc=0.00376853102255;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.04783653937; triggerSFBunc=0.00247601879159;triggerSFCDEF=0.978883600082; triggerSFCDEFunc=0.00805752356996;}
+	}
+	else if (eta > 1.442 && eta <= 2.0){
+	    if(pt >30.0 && pt <= 35.0){triggerSFB=1.22434938101; triggerSFBunc=0.0218235518324;triggerSFCDEF=0.986556201882; triggerSFCDEFunc=0.0215042582357;}
+	    else if(pt > 35.0 && pt <=40.0){triggerSFB=1.231305767; triggerSFBunc=0.0357351749146;triggerSFCDEF=1.01780514621; triggerSFCDEFunc=0.0334931969651;}
+	    else if(pt >40.0 && pt<=45.0){triggerSFB=1.17997761091; triggerSFBunc=0.040152142672;triggerSFCDEF=1.01890545164; triggerSFCDEFunc=0.0353809067738;}
+	    else if(pt >45.0 && pt <=50.0){triggerSFB=1.17228284782; triggerSFBunc=0.0101568501078;triggerSFCDEF=1.02366913264; triggerSFCDEFunc=0.0159136035832;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.10280648865; triggerSFBunc=0.0136560295169;triggerSFCDEF=0.987117193306; triggerSFCDEFunc=0.0100560754841;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.1679117327; triggerSFBunc=0.0741698407372;triggerSFCDEF=1.0680856167; triggerSFCDEFunc=0.068623275864;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.07915769032; triggerSFBunc=0.0109413337715;triggerSFCDEF=0.994679822421; triggerSFCDEFunc=0.00762790132034;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.08679975819; triggerSFBunc=0.00620436693934;triggerSFCDEF=1.00717797389; triggerSFCDEFunc=0.0151510689245;}
+	}
+	else if (eta > 2.0 && eta <= 2.4){
+	    if(pt >30.0 && pt <= 35.0){triggerSFB=1.22370728989; triggerSFBunc=0.0285118014412;triggerSFCDEF=1.00353720864; triggerSFCDEFunc=0.0453772901758;}
+	    else if(pt > 35.0 && pt <=40.0){triggerSFB=1.18312757909; triggerSFBunc=0.015933227322;triggerSFCDEF=0.935607479429; triggerSFCDEFunc=0.045376726802;}
+	    else if(pt >40.0 && pt<=45.0){triggerSFB=1.24146385007; triggerSFBunc=0.0551921513212;triggerSFCDEF=1.00575925128; triggerSFCDEFunc=0.0652837869259;}
+	    else if(pt >45.0 && pt <=50.0){triggerSFB=1.01577521883; triggerSFBunc=0.136561805823;triggerSFCDEF=0.950742260548; triggerSFCDEFunc=0.0437089261971;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.12059750687; triggerSFBunc=0.0109156647416;triggerSFCDEF=0.936123755289; triggerSFCDEFunc=0.0349139266772;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.06117478026; triggerSFBunc=0.0360468039116;triggerSFCDEF=0.911047525283; triggerSFCDEFunc=0.0239852531794;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.03333258161; triggerSFBunc=0.0596440436066;triggerSFCDEF=0.995804840183; triggerSFCDEFunc=0.0219341652245;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFB=0.552600867674; triggerSFBunc=0.39096055356;triggerSFCDEF=0.989342189114; triggerSFCDEFunc=0.0887423004862;}
+	}
+	/*if (ht > 500.0 && ht < 750.0){
 	  if (pt > 20.0 && pt < 50.0){triggerSFB = 0.907;triggerSFC = 0.968;triggerSFDEF = 0.970;}
 	  else if (pt >=50.0 && pt <= 300.0){triggerSFB = 0.904;triggerSFC = 0.997;triggerSFDEF = 0.998;}
 	}
 	else if (ht >= 750.0 && ht < 3000.0){
 	    if (pt > 20.0 && pt < 50.0){triggerSFB = 0.882;triggerSFC = 0.992;triggerSFDEF = 0.930;}
 	    else if (pt >=50.0 && pt <= 300.0){triggerSFB = 0.891;triggerSFC = 0.983;triggerSFDEF = 0.983;}
-	}
-	return (4.823*triggerSFB+ 9.664*triggerSFC + 27.07*triggerSFDEF)/41.557;
+	}*/
+	float triggerSFUncert = sqrt( pow(4.823*triggerSFBunc/41.557,2) + pow(36.734*triggerSFCDEFunc/41.557,2) );
+	float triggerSF = (4.823*triggerSFB + 36.734*triggerSFCDEF)/41.557;
+	return triggerSF;
 
 }
 
-double HardcodedConditions::GetMuonTriggerSF2018(double pt, double ht)
+double HardcodedConditions::GetMuonTriggerSF2018(double pt, double eta)
 {
-	float triggerSFAB = 1.0;
-	float triggerSFCD = 1.0;
-	if (ht > 500.0 && ht < 750.0){
+	float triggerSFABCD = 1.0;
+	float triggerSFABCDunc = 0.0;
+	if (eta > 0.0 && eta <= 0.8){
+	    if(pt >25.0 && pt <= 30.0){triggerSFABCD=0.94767883255; triggerSFABCDunc=0.00682250481374;}
+	    else if(pt >30.0 && pt <= 35.0){triggerSFABCD=0.975343471352; triggerSFABCDunc=0.00521575836242;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFABCD=0.979786994807; triggerSFABCDunc=0.00494941444298;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFABCD=0.982749255218; triggerSFABCDunc=0.00465578298111;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFABCD=0.984508302475; triggerSFABCDunc=0.00453720177682;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFABCD=0.984211706209; triggerSFABCDunc=0.00317949601845;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFABCD=0.985833185857; triggerSFABCDunc=0.00175732224141;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFABCD=0.9894052249; triggerSFABCDunc=0.00162976487427;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFABCD=0.98573388878; triggerSFABCDunc=0.00344224738942;}
+	}
+	else if (eta > 0.8 && eta <= 1.442){
+	    if(pt >25.0 && pt <= 30.0){triggerSFABCD=0.940534308542; triggerSFABCDunc=0.00945493136507;}
+	    else if(pt >30.0 && pt <= 35.0){triggerSFABCD=0.977250612414; triggerSFABCDunc=0.00720613736371;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFABCD=0.978939288095; triggerSFABCDunc=0.00691089368913;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFABCD=1.00221553593; triggerSFABCDunc=0.0060361955257;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFABCD=0.98279079978; triggerSFABCDunc=0.00628465006595;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFABCD=0.982680516659; triggerSFABCDunc=0.00452110678634;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFABCD=0.983137416465; triggerSFABCDunc=0.00257052834567;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFABCD=0.983626984691; triggerSFABCDunc=0.00275793170224;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFABCD=0.977732187568; triggerSFABCDunc=0.00592051551757;}
+	}
+	else if (eta > 1.442 && eta <= 2.0){
+	    if(pt >25.0 && pt <= 30.0){triggerSFABCD=0.984935935005; triggerSFABCDunc=0.0274745597906;}
+	    else if(pt >30.0 && pt <= 35.0){triggerSFABCD=0.993393945563; triggerSFABCDunc=0.0224931800147;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFABCD=0.969211890199; triggerSFABCDunc=0.0126944223266;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFABCD=1.01711048762; triggerSFABCDunc=0.0237901621894;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFABCD=1.00678501376; triggerSFABCDunc=0.0111245808153;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFABCD=1.02287293295; triggerSFABCDunc=0.0182139340892;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFABCD=1.00718248827; triggerSFABCDunc=0.00559986702137;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFABCD=1.01037269188; triggerSFABCDunc=0.00556910617477;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFABCD=1.0257553878; triggerSFABCDunc=0.0105437651897;}
+	}
+	else if (eta > 2.0 && eta <= 2.4){
+	    if(pt >25.0 && pt <= 30.0){triggerSFABCD=0.88440469579; triggerSFABCDunc=0.0414085800527;}
+	    else if(pt >30.0 && pt <= 35.0){triggerSFABCD=0.969619810729; triggerSFABCDunc=0.0356664367863;}
+	    else if(pt > 35.0 && pt <= 40.0){triggerSFABCD=1.01974116338; triggerSFABCDunc=0.031654361893;}
+	    else if(pt > 40.0 && pt <= 45.0){triggerSFABCD=1.02253219101; triggerSFABCDunc=0.0290017650303;}
+	    else if(pt > 45.0 && pt <= 50.0){triggerSFABCD=1.0096846675; triggerSFABCDunc=0.0315634676889;}
+	    else if(pt > 50.0 && pt <= 60.0){triggerSFABCD=1.04752858664; triggerSFABCDunc=0.0214622072212;}
+	    else if(pt > 60.0 && pt >= 100.0){triggerSFABCD=0.995781529538; triggerSFABCDunc=0.0175074289416;}
+	    else if(pt > 100.0 && pt >= 200.0){triggerSFABCD=1.03167948671; triggerSFABCDunc=0.0188983168656;}
+	    else if(pt >200.0 && pt >= 300.0){triggerSFABCD=0.980451308225; triggerSFABCDunc=0.0530839815221;}
+	}
+
+	/*if (ht > 500.0 && ht < 750.0){
 	  if (pt > 20.0 && pt < 50.0){triggerSFAB = 0.938;triggerSFCD = 0.948;}
 	  else if (pt >=50.0 && pt <= 300.0){triggerSFAB = 0.985;triggerSFCD = 0.996;}
 	}
 	else if (ht >= 750.0 && ht < 3000.0){
 	    if (pt > 20.0 && pt < 50.0){triggerSFAB = 0.921;triggerSFCD = 0.941;}
 	    else if (pt >=50.0 && pt <= 300.0){triggerSFAB = 0.974;triggerSFCD = 0.984;}
-	}
-	return (21.10*triggerSFAB+ 38.87*triggerSFCD)/59.97;
+	}*/
+	return triggerSFABCD;
 }
+
+
+
+/*.-----------------------------------------------------------------.
+  /  .-.                                                         .-.  \
+ |  /   \                                                       /   \  |
+ | |\_.  |                                                     |    /| |
+ |\|  | /|         HADRON TRIGGER SCALE FACTOR SECTION         |\  | |/|
+ | `---' |                  (For Muon Channel)                 | `---' |
+ |       |                                                     |       |
+ |       |-----------------------------------------------------|       |
+ \       |                                                     |       /
+  \     /                                                       \     /
+   `---'                                                         `---'*/
+
+double HardcodedConditions::GetIsMHadronTriggerSF(double njets, double ht, int year)
+{
+  //The main getter for Electron Trigger Scale Factors
+  if      (year==2016) return GetIsMHadronTriggerSF2016(njets, ht);
+  else if (year==2017) return GetIsMHadronTriggerSF2017(njets, ht);
+  else if (year==2018) return GetIsMHadronTriggerSF2018(njets, ht);
+  else return 0.;
+}//end GetElectronTriggerSF
+
+double HardcodedConditions::GetIsMHadronTriggerSF2016(double njets, double ht)
+{
+	// TO-BE-IMPLEMENTED!!!!!!!
+	return 1.000;
+
+}
+
+double HardcodedConditions::GetIsMHadronTriggerSF2017(double njets, double ht)
+{
+	// Trigger Scale Factors, SF2017B_Bkg_LepPtEta_EOR.png & SF2017CDEF_Bkg_LepPtEta_EOR.png
+	float triggerSFB = 1.0;
+	float triggerSFC = 1.0;
+	float triggerSFDEF = 1.0;
+	float triggerSFBunc = 0.0;
+	float triggerSFCunc = 0.0;
+	float triggerSFDEFunc = 0.0;
+	if (njets == 6){
+	    if(ht > 500.0 && ht < 675.0){triggerSFB=0.901326599437; triggerSFBunc=0.0354950845149;triggerSFC=1.19172560657; triggerSFCunc=0.0164392192176;triggerSFDEF=1.09823276295; triggerSFDEFunc=0.0100095399407;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFB=0.830153048387; triggerSFBunc=0.0514163341268;triggerSFC=1.06853722984; triggerSFCunc=0.0265488363692;triggerSFDEF=0.992368364074; triggerSFDEFunc=0.0153680492905;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFB=0.602324618842; triggerSFBunc=0.0744577774499;triggerSFC=0.968021708854; triggerSFCunc=0.0426049999959;triggerSFDEF=0.900528683477; triggerSFDEFunc=0.0246781298394;}
+	    else if(ht > 1025.0 ){triggerSFB=0.592984765997; triggerSFBunc=0.0753255460925;triggerSFC=0.877662462006; triggerSFCunc=0.0498138245222;triggerSFDEF=0.900231158951; triggerSFDEFunc=0.0284134132168;}
+	}
+	else if (njets == 7){
+	    if(ht > 500.0 && ht < 675.0){triggerSFB=0.888523145227; triggerSFBunc=0.0376657314246;triggerSFC=1.10996776087; triggerSFCunc=0.0183378530547;triggerSFDEF=1.05633176475; triggerSFDEFunc=0.0108103768438;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFB=0.77942085976; triggerSFBunc=0.0465047067053;triggerSFC=1.06057015809; triggerSFCunc=0.0262271488879;triggerSFDEF=0.983397354665; triggerSFDEFunc=0.0141916490162;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFB=0.635882535413; triggerSFBunc=0.0636807224067;triggerSFC=1.06057015809; triggerSFCunc=0.0262271488879;triggerSFDEF=0.933675813752; triggerSFDEFunc=0.0209332819546;}
+	    else if(ht > 1025.0 ){triggerSFB=0.56315405395; triggerSFBunc=0.0636124824921;triggerSFC=0.935923640798; triggerSFCunc=0.045168726139;triggerSFDEF=0.913210566682; triggerSFDEFunc=0.023095010078;}
+	}
+	else if (njets == 8){
+	    if(ht > 500.0 && ht < 675.0){triggerSFB=0.809731948392; triggerSFBunc=0.0557441511507;triggerSFC=1.09717908007; triggerSFCunc=0.0310553042709;triggerSFDEF=1.02895141685; triggerSFDEFunc=0.0176679617243;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFB=0.729024126758; triggerSFBunc=0.0597441485766;triggerSFC=1.0882040809; triggerSFCunc=0.0307231379301;triggerSFDEF=0.997978447484; triggerSFDEFunc=0.0189183840341;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFB=0.653313124493; triggerSFBunc=0.0711705888524;triggerSFC=0.975303164422; triggerSFCunc=0.0456403600603;triggerSFDEF=0.945354592444; triggerSFDEFunc=0.0256551175158;}
+	    else if(ht > 1025.0 ){triggerSFB=0.550424290651; triggerSFBunc=0.0674178254638;triggerSFC=0.748619204416; triggerSFCunc=0.0536522406822;triggerSFDEF=0.919439957568; triggerSFDEFunc=0.0252186935352; }
+	}
+	else if (njets >= 9){
+	    if(ht > 500.0 && ht < 675.0){triggerSFB=0.814496992569; triggerSFBunc=0.118371956733;triggerSFC=1.085125801; triggerSFCunc=0.0692566389692;triggerSFDEF=1.02280353055; triggerSFDEFunc=0.0354297237006;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFB=0.782492896323; triggerSFBunc=0.101728714292;triggerSFC=0.956428401548; triggerSFCunc=0.0581483146783;triggerSFDEF=1.00011547977; triggerSFDEFunc=0.0276193784769;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFB=0.752102032105; triggerSFBunc=0.100055276209;triggerSFC=0.949406721047; triggerSFCunc=0.0619238063511;triggerSFDEF=0.966483491257; triggerSFDEFunc=0.0331239016439;}
+	    else if(ht > 1025.0 ){triggerSFB=0.666638798389; triggerSFBunc=0.073370227875;triggerSFC=0.84948067102; triggerSFCunc=0.0531191922696;triggerSFDEF=0.891699501211; triggerSFDEFunc=0.027118923292;}
+	}
+    float triggerSFUncert = sqrt( pow(4.823*triggerSFBunc/41.557,2) + pow(9.664*triggerSFCunc/41.557,2) + pow(27.07*triggerSFDEFunc/41.557,2) );
+    float triggerSF = (4.823*triggerSFB+ 9.664*triggerSFC + 27.07*triggerSFDEF)/41.557;
+	return triggerSF;
+
+}
+
+double HardcodedConditions::GetIsMHadronTriggerSF2018(double njets, double ht)
+{
+  float triggerSFAB = 1.0;
+  float triggerSFCD = 1.0;
+  float triggerSFABunc = 0.0;
+  float triggerSFCDunc = 0.0;
+  	if (njets == 6){
+	    if(ht > 500.0 && ht < 675.0){triggerSFAB=0.917992750326; triggerSFABunc=0.0122463316509;triggerSFCD=0.939923153561; triggerSFCDunc=0.0082356257948;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFAB=0.846308380222; triggerSFABunc=0.0167618650341;triggerSFCD=0.867127741783; triggerSFCDunc=0.0114937087304;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFAB=0.756647287925; triggerSFABunc=0.0250683495324;triggerSFCD=0.786170997991; triggerSFCDunc=0.0166227550308;}
+	    else if(ht > 1025.0 ){triggerSFAB=0.769110750518; triggerSFABunc=0.0304131337995;triggerSFCD=0.834480666716; triggerSFCDunc=0.0195823674297;}
+	}
+	else if (njets == 7){
+	    if(ht > 500.0 && ht < 675.0){triggerSFAB=1.00833408459; triggerSFABunc=0.0128092215587; triggerSFCD=0.999895538188; triggerSFCDunc=0.00891742484208;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFAB=0.928336995294; triggerSFABunc=0.0171104567865;triggerSFCD=0.959939380589; triggerSFCDunc=0.0110178993694;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFAB=0.893208371203; triggerSFABunc=0.0245150164125;triggerSFCD=0.9330397495; triggerSFCDunc=0.016043807924;}
+	    else if(ht > 1025.0 ){triggerSFAB=0.8453263973; triggerSFABunc=0.0282535064794;triggerSFCD=0.949429540887; triggerSFCDunc=0.0175244609096;}
+	}
+	else if (njets == 8){
+	    if(ht > 500.0 && ht < 675.0){triggerSFAB=1.01216041006; triggerSFABunc=0.0202893598503;triggerSFCD=1.04087019648; triggerSFCDunc=0.013779196679;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFAB=0.97574520943; triggerSFABunc=0.0220361148103;triggerSFCD=0.970238811026; triggerSFCDunc=0.0145427369355;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFAB=0.923862342232; triggerSFABunc=0.028935592128;triggerSFCD=0.96157918255; triggerSFCDunc=0.018875465188;}
+	    else if(ht > 1025.0 ){triggerSFAB=0.938040650652; triggerSFABunc=0.0288231271496;triggerSFCD=0.96422449985; triggerSFCDunc=0.0195199213706;}
+
+	}
+	else if (njets >= 9){
+	    if(ht > 500.0 && ht < 675.0){triggerSFAB=1.10805831835; triggerSFABunc=0.0366536540938;triggerSFCD=1.04315580609; triggerSFCDunc=0.0265880677639;}
+	    else if(ht > 675.0 && ht < 850.0){triggerSFAB=0.973928026964; triggerSFABunc=0.0322303705451;triggerSFCD=1.01979486697; triggerSFCDunc=0.0212305462838;}
+	    else if(ht > 850.0 && ht < 1025.0){triggerSFAB=0.952334087619; triggerSFABunc=0.0367099921666;triggerSFCD=1.00054905845; triggerSFCDunc=0.0232230442621;}
+	    else if(ht > 1025.0 ){triggerSFAB=0.884807946965; triggerSFABunc=0.0337246901529;triggerSFCD=1.00428267929; triggerSFCDunc=0.0190601862132;}
+	}
+  float triggerSFUncert = sqrt( pow(21.10*triggerSFABunc/59.97,2) + pow(38.87*triggerSFCDunc/59.97,2) );
+  float triggerSF = (21.10*triggerSFAB+ 38.87*triggerSFCD)/59.97;
+  return triggerSF;
+}
+
+
 
 
 /*.-----------------------------------------------------------------.

--- a/step1/HardcodedConditions.cc
+++ b/step1/HardcodedConditions.cc
@@ -2854,23 +2854,23 @@ double HardcodedConditions::GetIsEHadronTriggerSF2018(double njets, double ht)
   \     /                                                       \     /
    `---'                                                         `---'*/
 
-double HardcodedConditions::GetElectronTriggerXSF(double pt, double eta, int year)
+double HardcodedConditions::GetElectronTriggerVlqXSF(double pt, double eta, int year)
 {
   //The main getter for Electron Trigger Scale Factors
-  if      (year==2016) return GetElectronTriggerXSF2016(pt, eta);
-  else if (year==2017) return GetElectronTriggerXSF2017(pt, eta);
-  else if (year==2018) return GetElectronTriggerXSF2018(pt, eta);
+  if      (year==2016) return GetElectronTriggerVlqXSF2016(pt, eta);
+  else if (year==2017) return GetElectronTriggerVlqXSF2017(pt, eta);
+  else if (year==2018) return GetElectronTriggerVlqXSF2018(pt, eta);
   else return 0.;
-}//end GetElectronTriggerXSF
+}//end GetElectronTriggerVlqXSF
 
-double HardcodedConditions::GetElectronTriggerXSF2016(double pt, double eta)
+double HardcodedConditions::GetElectronTriggerVlqXSF2016(double pt, double eta)
 {
 	// TO-BE-IMPLEMENTED!!!!!!!
 	return 1.000;
 
 }
 
-double HardcodedConditions::GetElectronTriggerXSF2017(double leppt, double lepeta)
+double HardcodedConditions::GetElectronTriggerVlqXSF2017(double leppt, double lepeta)
 {
 	  // Trigger Scale Factors, SF2017B_Bkg_LepPtEta_EOR.png & SF2017CDEF_Bkg_LepPtEta_EOR.png
 	  float trigSFB = 1.0;
@@ -2914,7 +2914,7 @@ double HardcodedConditions::GetElectronTriggerXSF2017(double leppt, double lepet
 
 }
 
-double HardcodedConditions::GetElectronTriggerXSF2018(double leppt, double lepeta)
+double HardcodedConditions::GetElectronTriggerVlqXSF2018(double leppt, double lepeta)
 {
 	  //Trigger SF calculated by JHogan, HT > 430, ttbar tag/probe, Id+iso applied
 	float triggSF = 1.0;
@@ -2971,6 +2971,309 @@ double HardcodedConditions::GetElectronTriggerXSF2018(double leppt, double lepet
 	 }
 
   return triggSF;
+}
+
+
+/*.-----------------------------------------------------------------.
+  /  .-.                                                         .-.  \
+ |  /   \                                                       /   \  |
+ | |\_.  |                                                     |    /| |
+ |\|  | /|      ELECTRON X-TRIGGER SCALE FACTOR SECTION        |\  | |/|
+ | `---' |                    (from Nikos)                     | `---' |
+ |       |                                                     |       |
+ |       |-----------------------------------------------------|       |
+ \       |                                                     |       /
+  \     /                                                       \     /
+   `---'                                                         `---'*/
+
+double HardcodedConditions::GetElectronTriggerXSF(double pt, double eta, int year)
+{
+  //The main getter for Electron Trigger Scale Factors
+  if      (year==2016) return GetElectronTriggerXSF2016(pt, eta);
+  else if (year==2017) return GetElectronTriggerXSF2017(pt, eta);
+  else if (year==2018) return GetElectronTriggerXSF2018(pt, eta);
+  else return 0. ;
+}//end GetElectronTriggerXSF
+
+double HardcodedConditions::GetElectronTriggerXSF2016(double pt, double eta)
+{
+	// TO-BE-IMPLEMENTED!!!!!!!
+	return 1.000 ;
+
+}
+
+double HardcodedConditions::GetElectronTriggerXSF2017(double leppt, double lepeta)
+{
+	  // Trigger Scale Factors, SF2017B_Bkg_LepPtEta_EOR.png & SF2017CDEF_Bkg_LepPtEta_EOR.png
+	  float trigSFB = 1.0;
+	  float trigSFCDEF = 1.0;
+	  float trigSFBunc = 0.0;
+	  float trigSFCDEFunc = 0.0;
+	  if (fabs(lepeta) < 0.8){
+        if (leppt >=20.0 &&  leppt< 25.0 ) {
+            trigSFB=0.0; trigSFBunc=-1;
+            trigSFCDEF=1.08552840991; trigSFCDEFunc=0.00887273637568;
+            }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {
+            trigSFB=0.0; trigSFBunc=-1;
+            trigSFCDEF=1.07082446672; trigSFCDEFunc=0.00381687027718;
+            }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {
+            trigSFB=0.0156991498666; trigSFBunc=0.00899912206167;
+            trigSFCDEF=1.04732309472; trigSFCDEFunc=0.00912405345717;
+            }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {
+            trigSFB=0.853055863294; trigSFBunc=0.0280478272024;
+            trigSFCDEF=1.04001604765; trigSFCDEFunc=0.00398221313048;
+            }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {
+            trigSFB=1.05266545066; trigSFBunc=0.0125523044299;
+            trigSFCDEF=1.0474195663; trigSFCDEFunc=0.00945736440857;
+            }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {
+            trigSFB=1.0446917778; trigSFBunc=0.00443218948007;
+            trigSFCDEF=1.04057499109; trigSFCDEFunc=0.00254763009755;
+            }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {
+            trigSFB=1.04499711786; trigSFBunc=0.00370247485863;
+            trigSFCDEF=1.01884743033; trigSFCDEFunc=0.00313913252463;
+            }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {
+            trigSFB=1.03288832639; trigSFBunc=0.00550597705563;
+            trigSFCDEF=1.01753508381; trigSFCDEFunc=0.00308512823087;
+            }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {
+            trigSFB=1.02883916576; trigSFBunc=0.00213991694503;
+            trigSFCDEF=1.01383390053; trigSFCDEFunc=0.00173857940949;
+            }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {
+            trigSFB=1.01507401909; trigSFBunc=0.00226096652583;
+            trigSFCDEF=1.00616018347; trigSFCDEFunc=0.0013878685792;
+            }
+        else{
+            trigSFB=1.0102603482; trigSFBunc=0.000747218314445;
+            trigSFCDEF=1.00479357143; trigSFCDEFunc=0.00187741895;
+            }
+	  }
+	  else if (fabs(lepeta) < 1.442){
+        if (leppt >=20.0 &&  leppt< 25.0 ) {
+            trigSFB=0.760119797875; trigSFBunc=0.310337896775;
+            trigSFCDEF=1.13746928549; trigSFCDEFunc=0.00553544345872;
+            }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {
+            trigSFB=0.0; trigSFBunc=-1;
+            trigSFCDEF=1.12676244222; trigSFCDEFunc=0.015444776283;
+            }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {
+            trigSFB=0.0; trigSFBunc=-1;
+            trigSFCDEF=1.07272481048; trigSFCDEFunc=0.00661657111514;
+            }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {
+            trigSFB=0.790278711561; trigSFBunc=0.0411165609489;
+            trigSFCDEF=1.05882334456; trigSFCDEFunc=0.00511065558603;
+            }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {
+            trigSFB=1.06945574436; trigSFBunc=0.00290318383937;
+            trigSFCDEF=1.05540570753; trigSFCDEFunc=0.00443484967063;
+            }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {
+            trigSFB=1.06334514688; trigSFBunc=0.0023530829504;
+            trigSFCDEF=1.05453532794; trigSFCDEFunc=0.00362527515816;
+            }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {
+            trigSFB=1.06349511204; trigSFBunc=0.0049802813825;
+            trigSFCDEF=1.03133914935; trigSFCDEFunc=0.00474770949689;
+            }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {
+            trigSFB=1.06692865386; trigSFBunc=0.0181708799599;
+            trigSFCDEF=1.05458294543; trigSFCDEFunc=0.0157703426718;
+            }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {
+            trigSFB=1.04105444789; trigSFBunc=0.00123767565196;
+            trigSFCDEF=1.0184760525; trigSFCDEFunc=0.00273402347531;
+            }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {
+            trigSFB=1.02152635173; trigSFBunc=0.00313051739258;
+            trigSFCDEF=1.01085198147; trigSFCDEFunc=0.00205741257245;
+            }
+        else{
+            trigSFB=1.01376673793; trigSFBunc=0.00130427393468;
+            trigSFCDEF=1.00697812138; trigSFCDEFunc=0.00305088102889;
+            }
+	  }
+	  else if (fabs(lepeta) < 1.566) {trigSFB = 1.0; trigSFCDEF = 1.0;}
+	  else if (fabs(lepeta) < 2.0){
+         if (leppt >=20.0 &&  leppt< 25.0 ) {
+            trigSFB=0.0; trigSFBunc=-1;
+            trigSFCDEF=1.19909358081; trigSFCDEFunc=0.0353376191772;
+            }
+         else if (leppt >=25.0 &&  leppt< 30.0 ) {
+            trigSFB=0.0; trigSFBunc=-1;
+            trigSFCDEF=1.09481419439; trigSFCDEFunc=0.0304477030337;
+            }
+         else if (leppt >=30.0 &&  leppt< 35.0 ) {
+            trigSFB=0.0514234061329; trigSFBunc=0.0356155490968;
+            trigSFCDEF=1.1072593802; trigSFCDEFunc=0.0368965723703;
+            }
+         else if (leppt >=35.0 &&  leppt< 40.0 ) {
+            trigSFB=0.664907397575; trigSFBunc=0.0860296378044;
+            trigSFCDEF=1.05256406493; trigSFCDEFunc=0.0138144332818;
+            }
+         else if (leppt >=40.0 &&  leppt< 45.0 ) {
+            trigSFB=1.05025561699; trigSFBunc=0.0215543893492;
+            trigSFCDEF=1.05848583952; trigSFCDEFunc=0.00658000222521;
+            }
+         else if (leppt >=45.0 &&  leppt< 50.0 ) {
+            trigSFB=1.10222475298; trigSFBunc=0.0124495163302;
+            trigSFCDEF=1.09740101227; trigSFCDEFunc=0.0128537992993;
+            }
+         else if (leppt >=50.0 &&  leppt< 60.0 ) {
+            trigSFB=1.07732214728; trigSFBunc=0.0055355236644;
+            trigSFCDEF=1.04684439896; trigSFCDEFunc=0.008256931132;
+            }
+         else if (leppt >=60.0 &&  leppt< 70.0 ) {
+            trigSFB=1.056582036; trigSFBunc=0.00344137348184;
+            trigSFCDEF=1.00469631102; trigSFCDEFunc=0.00939584806876;
+            }
+         else if (leppt >=70.0 &&  leppt< 100.0 ) {
+            trigSFB=1.06256856682; trigSFBunc=0.00470393138296;
+            trigSFCDEF=1.0342999195; trigSFCDEFunc=0.00662143745353;
+            }
+         else if (leppt >=100.0 &&  leppt< 200.0 ) {
+            trigSFB=1.05522146539; trigSFBunc=0.0161323213105;
+            trigSFCDEF=1.01830159313; trigSFCDEFunc=0.0165211825975;
+            }
+         else {
+            trigSFB=1.0461007528; trigSFBunc=0.0149238889107;
+            trigSFCDEF=1.01904642299; trigSFCDEFunc=0.0181710170484;
+            }
+	  }
+	  else {
+        if (leppt >=20.0 &&  leppt< 25.0 ) {
+            trigSFB=0.0; trigSFBunc=-1;
+            trigSFCDEF=1.19647528076; trigSFCDEFunc=0.0279497916168;
+            }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {
+            trigSFB=0.0; trigSFBunc=-1;
+            trigSFCDEF=1.16882475468; trigSFCDEFunc=0.0195107691178;
+            }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {
+            trigSFB=0.0; trigSFBunc=-1;
+            trigSFCDEF=1.17514382045; trigSFCDEFunc=0.169165525113;
+            }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {
+            trigSFB=0.543989860379; trigSFBunc=0.14547991002;
+            trigSFCDEF=1.05250212117; trigSFCDEFunc=0.0225076340631;
+            }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {
+            trigSFB=1.05739184941; trigSFBunc=0.00789047727968;
+            trigSFCDEF=1.04347879876; trigSFCDEFunc=0.0158637311148;
+            }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {
+            trigSFB=1.07552884368; trigSFBunc=0.0106829876111;
+            trigSFCDEF=1.07552884368; trigSFCDEFunc=0.0106829876111;
+            }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {
+            trigSFB=1.06785906602; trigSFBunc=0.0077301392061;
+            trigSFCDEF=1.04047806433; trigSFCDEFunc=0.0173271041498;
+            }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {
+            trigSFB=1.05894469804; trigSFBunc=0.00771611811371;
+            trigSFCDEF=1.02868913524; trigSFCDEFunc=0.0187776415751;
+            }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {
+            trigSFB=1.03854075672; trigSFBunc=0.00552514353362;
+            trigSFCDEF=1.0033359853; trigSFCDEFunc=0.0151014297158;
+            }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {
+            trigSFB=1.03658177237; trigSFBunc=0.00528984872319;
+            trigSFCDEF=1.03075827927; trigSFCDEFunc=0.00783527418978;
+            }
+        else {
+            trigSFB=1.01020550365; trigSFBunc=0.00779170145734;
+            trigSFCDEF=1.01020550365; trigSFCDEFunc=0.00779170145733;
+            }
+	  }
+	  float triggerSF = (4.823*trigSFB + 36.734*trigSFCDEF)/41.557;
+	  float triggerSFUncert = sqrt( pow(4.823*trigSFBunc/41.557,2) + pow(36.734*trigSFCDEFunc/41.557,2) );
+
+	return triggerSF;
+
+}
+
+double HardcodedConditions::GetElectronTriggerXSF2018(double leppt, double lepeta)
+{
+	  //Trigger SF calculated by JHogan, HT >= 430, ttbar tag/probe, Id+iso applied
+	float triggerSF18 = 1.0;
+	float triggSF18Uncert = 1.0;
+	  if (fabs(lepeta) < 0.8){
+        if (leppt >=20.0 &&  leppt< 25.0 ) {triggerSF18=1.0670314856; triggSF18Uncert=0.00875315267781; }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {triggerSF18=1.0499128083; triggSF18Uncert=0.0031247165944; }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {triggerSF18=1.00621041046; triggSF18Uncert=0.0042497979947; }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {triggerSF18=1.02422795836; triggSF18Uncert=0.00310166286402; }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {triggerSF18=1.03558904355; triggSF18Uncert=0.00263344920681; }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {triggerSF18=1.03474716309; triggSF18Uncert=0.0027799671747; }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {triggerSF18=1.01260027831; triggSF18Uncert=0.00271688757315; }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {triggerSF18=1.01212305341; triggSF18Uncert=0.0062052448711; }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {triggerSF18=1.00340088961; triggSF18Uncert=0.00176541102064; }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {triggerSF18=0.997574205522; triggSF18Uncert=0.00134545610057; }
+        else  {triggerSF18=0.992697058409; triggSF18Uncert=0.00253795050908; }
+
+        }
+	  else if (fabs(lepeta) < 1.442){
+        if (leppt >=20.0 &&  leppt< 25.0 ) {triggerSF18=1.12437681739; triggSF18Uncert=0.0075932996865; }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {triggerSF18=1.07550983066; triggSF18Uncert=0.00476577651126; }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {triggerSF18=1.03084039204; triggSF18Uncert=0.00668735845147; }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {triggerSF18=1.04138824358; triggSF18Uncert=0.00538137691034; }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {triggerSF18=1.05097643048; triggSF18Uncert=0.00372239498395; }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {triggerSF18=1.04234383328; triggSF18Uncert=0.00366667742861; }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {triggerSF18=1.04143606614; triggSF18Uncert=0.00970715361379; }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {triggerSF18=1.01722246158; triggSF18Uncert=0.00392759954486; }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {triggerSF18=1.0104522892; triggSF18Uncert=0.00236855031138; }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {triggerSF18=0.999831753333; triggSF18Uncert=0.00195210024845; }
+        else  {triggerSF18=0.994175176655; triggSF18Uncert=0.00377857034203; }
+	  }
+	  else if (fabs(lepeta) < 1.556) {
+        if (leppt >20.0 &&  leppt< 25.0 ) {triggerSF18=1.10295078323; triggSF18Uncert=0.0488865333795; }
+        else if (leppt >25.0 &&  leppt< 30.0 ) {triggerSF18=0.966520520194; triggSF18Uncert=0.120705655633; }
+        else if (leppt >30.0 &&  leppt< 35.0 ) {triggerSF18=1.17938320259; triggSF18Uncert=0.0718021261304; }
+        else if (leppt >35.0 &&  leppt< 40.0 ) {triggerSF18=1.20616437001; triggSF18Uncert=0.0833560551485; }
+        else if (leppt >40.0 &&  leppt< 45.0 ) {triggerSF18=1.00507840459; triggSF18Uncert=0.00274864693113; }
+        else if (leppt >45.0 &&  leppt< 50.0 ) {triggerSF18=1.06623280502; triggSF18Uncert=0.0402149474372; }
+        else if (leppt >50.0 &&  leppt< 60.0 ) {triggerSF18=1.04420037013; triggSF18Uncert=0.0733326506729; }
+        else if (leppt >60.0 &&  leppt< 70.0 ) {triggerSF18=1.01462540061; triggSF18Uncert=0.102066537958; }
+        else if (leppt >70.0 &&  leppt< 100.0 ) {triggerSF18=1.01012931644; triggSF18Uncert=0.0048494662106; }
+        else if (leppt >100.0 &&  leppt< 200.0 ) {triggerSF18=1.01360957744; triggSF18Uncert=0.0100629574181; }
+        else {triggerSF18=1.04274527761; triggSF18Uncert=0.044572436364;}
+	  }
+	  else if (fabs(lepeta) < 2.0){
+        if (leppt >=20.0 &&  leppt< 25.0 ) {triggerSF18=1.15666001871; triggSF18Uncert=0.015073354568; }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {triggerSF18=1.1338916502; triggSF18Uncert=0.0321732752939; }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {triggerSF18=1.07908854656; triggSF18Uncert=0.0424636253445; }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {triggerSF18=1.04624854566; triggSF18Uncert=0.00917693729306; }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {triggerSF18=1.04936439127; triggSF18Uncert=0.00551224232629; }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {triggerSF18=1.04541518191; triggSF18Uncert=0.0059241055789; }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {triggerSF18=1.05091611938; triggSF18Uncert=0.023416971145; }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {triggerSF18=1.00314941274; triggSF18Uncert=0.00735793260239; }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {triggerSF18=1.0014071838; triggSF18Uncert=0.00613007877119; }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {triggerSF18=1.0195049775; triggSF18Uncert=0.0154470471865; }
+        else  {triggerSF18=0.995298816473; triggSF18Uncert=0.0179251546103; }
+        }
+	  else{
+        if (leppt >=20.0 &&  leppt< 25.0 ) {triggerSF18=1.09987049201; triggSF18Uncert=0.00562440298325; }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {triggerSF18=1.07122500883; triggSF18Uncert=0.00484044388043; }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {triggerSF18=1.02429081991; triggSF18Uncert=0.00647104843698; }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {triggerSF18=1.03217586081; triggSF18Uncert=0.00266548321738; }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {triggerSF18=1.04681708088; triggSF18Uncert=0.00494532195691; }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {triggerSF18=1.03886408622; triggSF18Uncert=0.00204087554649; }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {triggerSF18=1.02608538098; triggSF18Uncert=0.00435004675606; }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {triggerSF18=1.01291470554; triggSF18Uncert=0.00379132821594; }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {triggerSF18=1.00525339733; triggSF18Uncert=0.00141842634418; }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {triggerSF18=1.00016819985; triggSF18Uncert=0.00175247967539; }
+        else {triggerSF18=0.993999916871; triggSF18Uncert=0.00260426298855; }
+	 }
+
+  return triggerSF18;
 }
 
 
@@ -3245,60 +3548,60 @@ double HardcodedConditions::GetMuonTriggerSF2016(double pt, double eta)
 
 double HardcodedConditions::GetMuonTriggerSF2017(double pt, double eta)
 {
-	float triggerSFB = 1.0;
+	float trigSFB = 1.0;
 	float triggerSFCDEF = 1.0;
-	float triggerSFBunc = 0.0;
+	float trigSFBunc = 0.0;
 	float triggerSFCDEFunc = 0.0;
 	if (eta > 0.0 && eta <= 0.8){
-	    if(pt >30.0 && pt <= 35.0){triggerSFB=1.10019349994; triggerSFBunc=0.00547206712151;triggerSFCDEF=0.978804954631; triggerSFCDEFunc=0.00648538520448;}
-	    else if(pt > 35.0 && pt <= 40.0){triggerSFB=1.09211088948; triggerSFBunc=0.00204401887493;triggerSFCDEF=0.984698671039; triggerSFCDEFunc=0.00602193913522;}
-	    else if(pt > 40.0 && pt <= 45.0){triggerSFB=1.07808450861; triggerSFBunc=0.00464941695873;triggerSFCDEF=0.995559844257; triggerSFCDEFunc=0.00567940378055;}
-	    else if(pt > 45.0 && pt <= 50.0){triggerSFB=1.07193586473; triggerSFBunc=0.00391132533692;triggerSFCDEF=0.988591733802; triggerSFCDEFunc=0.00579494608742;}
-	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.01367573178; triggerSFBunc=0.00984912438091;triggerSFCDEF=0.990844343111; triggerSFCDEFunc=0.00401810293322;}
-	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.02371459077; triggerSFBunc=0.00453347155488;triggerSFCDEF=0.9899251109; triggerSFCDEFunc=0.00222019796691;}
-	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.01917413639; triggerSFBunc=0.00428822026176;triggerSFCDEF=0.989816219066; triggerSFCDEFunc=0.00213658604325;}
-	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.03021004051; triggerSFBunc=0.0047931519218;triggerSFCDEF=0.993698209245; triggerSFCDEFunc=0.00407479066069;}
+	    if(pt >30.0 && pt <= 35.0){trigSFB=1.10019349994; trigSFBunc=0.00547206712151;triggerSFCDEF=0.978804954631; triggerSFCDEFunc=0.00648538520448;}
+	    else if(pt > 35.0 && pt <= 40.0){trigSFB=1.09211088948; trigSFBunc=0.00204401887493;triggerSFCDEF=0.984698671039; triggerSFCDEFunc=0.00602193913522;}
+	    else if(pt > 40.0 && pt <= 45.0){trigSFB=1.07808450861; trigSFBunc=0.00464941695873;triggerSFCDEF=0.995559844257; triggerSFCDEFunc=0.00567940378055;}
+	    else if(pt > 45.0 && pt <= 50.0){trigSFB=1.07193586473; trigSFBunc=0.00391132533692;triggerSFCDEF=0.988591733802; triggerSFCDEFunc=0.00579494608742;}
+	    else if(pt > 50.0 && pt <= 60.0){trigSFB=1.01367573178; trigSFBunc=0.00984912438091;triggerSFCDEF=0.990844343111; triggerSFCDEFunc=0.00401810293322;}
+	    else if(pt > 60.0 && pt >= 100.0){trigSFB=1.02371459077; trigSFBunc=0.00453347155488;triggerSFCDEF=0.9899251109; triggerSFCDEFunc=0.00222019796691;}
+	    else if(pt > 100.0 && pt >= 200.0){trigSFB=1.01917413639; trigSFBunc=0.00428822026176;triggerSFCDEF=0.989816219066; triggerSFCDEFunc=0.00213658604325;}
+	    else if(pt >200.0 && pt >= 300.0){trigSFB=1.03021004051; trigSFBunc=0.0047931519218;triggerSFCDEF=0.993698209245; triggerSFCDEFunc=0.00407479066069;}
 	}
     else if (eta > 0.8 && eta <= 1.442){
-	    if(pt >30.0 && pt <= 35.0){triggerSFB=1.12077327256; triggerSFBunc=0.0113246985811;triggerSFCDEF=0.965099847017; triggerSFCDEFunc=0.00969574453469;}
-	    else if(pt > 35.0 && pt <=40.0){triggerSFB=1.11606710619; triggerSFBunc=0.00305398442218;triggerSFCDEF=0.974018899838; triggerSFCDEFunc=0.00871241069532;}
-	    else if(pt >40.0 && pt<=45.0){triggerSFB=1.10646659029; triggerSFBunc=0.00302169373442;triggerSFCDEF=1.00039705989; triggerSFCDEFunc=0.00799929230775;}
-	    else if(pt >45.0 && pt <=50.0){triggerSFB=1.08923843408; triggerSFBunc=0.00285057860769;triggerSFCDEF=0.979438599873; triggerSFCDEFunc=0.00829713158194;}
-	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.0428344034; triggerSFBunc=0.0107394273425;triggerSFCDEF=0.987897428252; triggerSFCDEFunc=0.0057226921376;}
-	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.04106960725; triggerSFBunc=0.00590548911614;triggerSFCDEF=0.984113306672; triggerSFCDEFunc=0.00341488478406;}
-	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.03213107411; triggerSFBunc=0.00600579292185;triggerSFCDEF=0.976053564253; triggerSFCDEFunc=0.00376853102255;}
-	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.04783653937; triggerSFBunc=0.00247601879159;triggerSFCDEF=0.978883600082; triggerSFCDEFunc=0.00805752356996;}
+	    if(pt >30.0 && pt <= 35.0){trigSFB=1.12077327256; trigSFBunc=0.0113246985811;triggerSFCDEF=0.965099847017; triggerSFCDEFunc=0.00969574453469;}
+	    else if(pt > 35.0 && pt <=40.0){trigSFB=1.11606710619; trigSFBunc=0.00305398442218;triggerSFCDEF=0.974018899838; triggerSFCDEFunc=0.00871241069532;}
+	    else if(pt >40.0 && pt<=45.0){trigSFB=1.10646659029; trigSFBunc=0.00302169373442;triggerSFCDEF=1.00039705989; triggerSFCDEFunc=0.00799929230775;}
+	    else if(pt >45.0 && pt <=50.0){trigSFB=1.08923843408; trigSFBunc=0.00285057860769;triggerSFCDEF=0.979438599873; triggerSFCDEFunc=0.00829713158194;}
+	    else if(pt > 50.0 && pt <= 60.0){trigSFB=1.0428344034; trigSFBunc=0.0107394273425;triggerSFCDEF=0.987897428252; triggerSFCDEFunc=0.0057226921376;}
+	    else if(pt > 60.0 && pt >= 100.0){trigSFB=1.04106960725; trigSFBunc=0.00590548911614;triggerSFCDEF=0.984113306672; triggerSFCDEFunc=0.00341488478406;}
+	    else if(pt > 100.0 && pt >= 200.0){trigSFB=1.03213107411; trigSFBunc=0.00600579292185;triggerSFCDEF=0.976053564253; triggerSFCDEFunc=0.00376853102255;}
+	    else if(pt >200.0 && pt >= 300.0){trigSFB=1.04783653937; trigSFBunc=0.00247601879159;triggerSFCDEF=0.978883600082; triggerSFCDEFunc=0.00805752356996;}
 	}
 	else if (eta > 1.442 && eta <= 2.0){
-	    if(pt >30.0 && pt <= 35.0){triggerSFB=1.22434938101; triggerSFBunc=0.0218235518324;triggerSFCDEF=0.986556201882; triggerSFCDEFunc=0.0215042582357;}
-	    else if(pt > 35.0 && pt <=40.0){triggerSFB=1.231305767; triggerSFBunc=0.0357351749146;triggerSFCDEF=1.01780514621; triggerSFCDEFunc=0.0334931969651;}
-	    else if(pt >40.0 && pt<=45.0){triggerSFB=1.17997761091; triggerSFBunc=0.040152142672;triggerSFCDEF=1.01890545164; triggerSFCDEFunc=0.0353809067738;}
-	    else if(pt >45.0 && pt <=50.0){triggerSFB=1.17228284782; triggerSFBunc=0.0101568501078;triggerSFCDEF=1.02366913264; triggerSFCDEFunc=0.0159136035832;}
-	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.10280648865; triggerSFBunc=0.0136560295169;triggerSFCDEF=0.987117193306; triggerSFCDEFunc=0.0100560754841;}
-	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.1679117327; triggerSFBunc=0.0741698407372;triggerSFCDEF=1.0680856167; triggerSFCDEFunc=0.068623275864;}
-	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.07915769032; triggerSFBunc=0.0109413337715;triggerSFCDEF=0.994679822421; triggerSFCDEFunc=0.00762790132034;}
-	    else if(pt >200.0 && pt >= 300.0){triggerSFB=1.08679975819; triggerSFBunc=0.00620436693934;triggerSFCDEF=1.00717797389; triggerSFCDEFunc=0.0151510689245;}
+	    if(pt >30.0 && pt <= 35.0){trigSFB=1.22434938101; trigSFBunc=0.0218235518324;triggerSFCDEF=0.986556201882; triggerSFCDEFunc=0.0215042582357;}
+	    else if(pt > 35.0 && pt <=40.0){trigSFB=1.231305767; trigSFBunc=0.0357351749146;triggerSFCDEF=1.01780514621; triggerSFCDEFunc=0.0334931969651;}
+	    else if(pt >40.0 && pt<=45.0){trigSFB=1.17997761091; trigSFBunc=0.040152142672;triggerSFCDEF=1.01890545164; triggerSFCDEFunc=0.0353809067738;}
+	    else if(pt >45.0 && pt <=50.0){trigSFB=1.17228284782; trigSFBunc=0.0101568501078;triggerSFCDEF=1.02366913264; triggerSFCDEFunc=0.0159136035832;}
+	    else if(pt > 50.0 && pt <= 60.0){trigSFB=1.10280648865; trigSFBunc=0.0136560295169;triggerSFCDEF=0.987117193306; triggerSFCDEFunc=0.0100560754841;}
+	    else if(pt > 60.0 && pt >= 100.0){trigSFB=1.1679117327; trigSFBunc=0.0741698407372;triggerSFCDEF=1.0680856167; triggerSFCDEFunc=0.068623275864;}
+	    else if(pt > 100.0 && pt >= 200.0){trigSFB=1.07915769032; trigSFBunc=0.0109413337715;triggerSFCDEF=0.994679822421; triggerSFCDEFunc=0.00762790132034;}
+	    else if(pt >200.0 && pt >= 300.0){trigSFB=1.08679975819; trigSFBunc=0.00620436693934;triggerSFCDEF=1.00717797389; triggerSFCDEFunc=0.0151510689245;}
 	}
 	else if (eta > 2.0 && eta <= 2.4){
-	    if(pt >30.0 && pt <= 35.0){triggerSFB=1.22370728989; triggerSFBunc=0.0285118014412;triggerSFCDEF=1.00353720864; triggerSFCDEFunc=0.0453772901758;}
-	    else if(pt > 35.0 && pt <=40.0){triggerSFB=1.18312757909; triggerSFBunc=0.015933227322;triggerSFCDEF=0.935607479429; triggerSFCDEFunc=0.045376726802;}
-	    else if(pt >40.0 && pt<=45.0){triggerSFB=1.24146385007; triggerSFBunc=0.0551921513212;triggerSFCDEF=1.00575925128; triggerSFCDEFunc=0.0652837869259;}
-	    else if(pt >45.0 && pt <=50.0){triggerSFB=1.01577521883; triggerSFBunc=0.136561805823;triggerSFCDEF=0.950742260548; triggerSFCDEFunc=0.0437089261971;}
-	    else if(pt > 50.0 && pt <= 60.0){triggerSFB=1.12059750687; triggerSFBunc=0.0109156647416;triggerSFCDEF=0.936123755289; triggerSFCDEFunc=0.0349139266772;}
-	    else if(pt > 60.0 && pt >= 100.0){triggerSFB=1.06117478026; triggerSFBunc=0.0360468039116;triggerSFCDEF=0.911047525283; triggerSFCDEFunc=0.0239852531794;}
-	    else if(pt > 100.0 && pt >= 200.0){triggerSFB=1.03333258161; triggerSFBunc=0.0596440436066;triggerSFCDEF=0.995804840183; triggerSFCDEFunc=0.0219341652245;}
-	    else if(pt >200.0 && pt >= 300.0){triggerSFB=0.552600867674; triggerSFBunc=0.39096055356;triggerSFCDEF=0.989342189114; triggerSFCDEFunc=0.0887423004862;}
+	    if(pt >30.0 && pt <= 35.0){trigSFB=1.22370728989; trigSFBunc=0.0285118014412;triggerSFCDEF=1.00353720864; triggerSFCDEFunc=0.0453772901758;}
+	    else if(pt > 35.0 && pt <=40.0){trigSFB=1.18312757909; trigSFBunc=0.015933227322;triggerSFCDEF=0.935607479429; triggerSFCDEFunc=0.045376726802;}
+	    else if(pt >40.0 && pt<=45.0){trigSFB=1.24146385007; trigSFBunc=0.0551921513212;triggerSFCDEF=1.00575925128; triggerSFCDEFunc=0.0652837869259;}
+	    else if(pt >45.0 && pt <=50.0){trigSFB=1.01577521883; trigSFBunc=0.136561805823;triggerSFCDEF=0.950742260548; triggerSFCDEFunc=0.0437089261971;}
+	    else if(pt > 50.0 && pt <= 60.0){trigSFB=1.12059750687; trigSFBunc=0.0109156647416;triggerSFCDEF=0.936123755289; triggerSFCDEFunc=0.0349139266772;}
+	    else if(pt > 60.0 && pt >= 100.0){trigSFB=1.06117478026; trigSFBunc=0.0360468039116;triggerSFCDEF=0.911047525283; triggerSFCDEFunc=0.0239852531794;}
+	    else if(pt > 100.0 && pt >= 200.0){trigSFB=1.03333258161; trigSFBunc=0.0596440436066;triggerSFCDEF=0.995804840183; triggerSFCDEFunc=0.0219341652245;}
+	    else if(pt >200.0 && pt >= 300.0){trigSFB=0.552600867674; trigSFBunc=0.39096055356;triggerSFCDEF=0.989342189114; triggerSFCDEFunc=0.0887423004862;}
 	}
 	/*if (ht > 500.0 && ht < 750.0){
-	  if (pt > 20.0 && pt < 50.0){triggerSFB = 0.907;triggerSFC = 0.968;triggerSFDEF = 0.970;}
-	  else if (pt >=50.0 && pt <= 300.0){triggerSFB = 0.904;triggerSFC = 0.997;triggerSFDEF = 0.998;}
+	  if (pt > 20.0 && pt < 50.0){trigSFB = 0.907;triggerSFC = 0.968;triggerSFDEF = 0.970;}
+	  else if (pt >=50.0 && pt <= 300.0){trigSFB = 0.904;triggerSFC = 0.997;triggerSFDEF = 0.998;}
 	}
 	else if (ht >= 750.0 && ht < 3000.0){
-	    if (pt > 20.0 && pt < 50.0){triggerSFB = 0.882;triggerSFC = 0.992;triggerSFDEF = 0.930;}
-	    else if (pt >=50.0 && pt <= 300.0){triggerSFB = 0.891;triggerSFC = 0.983;triggerSFDEF = 0.983;}
+	    if (pt > 20.0 && pt < 50.0){trigSFB = 0.882;triggerSFC = 0.992;triggerSFDEF = 0.930;}
+	    else if (pt >=50.0 && pt <= 300.0){trigSFB = 0.891;triggerSFC = 0.983;triggerSFDEF = 0.983;}
 	}*/
-	float triggerSFUncert = sqrt( pow(4.823*triggerSFBunc/41.557,2) + pow(36.734*triggerSFCDEFunc/41.557,2) );
-	float triggerSF = (4.823*triggerSFB + 36.734*triggerSFCDEF)/41.557;
+	float triggerSFUncert = sqrt( pow(4.823*trigSFBunc/41.557,2) + pow(36.734*triggerSFCDEFunc/41.557,2) );
+	float triggerSF = (4.823*trigSFB + 36.734*triggerSFCDEF)/41.557;
 	return triggerSF;
 
 }
@@ -3483,23 +3786,23 @@ double HardcodedConditions::GetIsMHadronTriggerSF2018(double njets, double ht)
   \     /                                                       \     /
    `---'                                                         `---'*/
 
-double HardcodedConditions::GetMuonTriggerXSF(double pt, double eta, int year)
+double HardcodedConditions::GetMuonTriggerVlqXSF(double pt, double eta, int year)
 {
   //The main getter for Muon Trigger Scale Factors
-  if      (year==2016) return GetMuonTriggerXSF2016(pt, eta);
-  else if (year==2017) return GetMuonTriggerXSF2017(pt, eta);
-  else if (year==2018) return GetMuonTriggerXSF2018(pt, eta);
+  if      (year==2016) return GetMuonTriggerVlqXSF2016(pt, eta);
+  else if (year==2017) return GetMuonTriggerVlqXSF2017(pt, eta);
+  else if (year==2018) return GetMuonTriggerVlqXSF2018(pt, eta);
   else return 0.;
-}//end GetMuonTriggerXSF
+}//end GetMuonTriggerVlqXSF
 
-double HardcodedConditions::GetMuonTriggerXSF2016(double pt, double eta)
+double HardcodedConditions::GetMuonTriggerVlqXSF2016(double pt, double eta)
 {
 	// TO-BE-IMPLEMENTED!!!!!!!
 	return 1.000;
 
 }
 
-double HardcodedConditions::GetMuonTriggerXSF2017(double leppt, double lepeta)
+double HardcodedConditions::GetMuonTriggerVlqXSF2017(double leppt, double lepeta)
 {
 	  float triggerSFB = 1.0;
 	  float triggerSFCDEF = 1.0;
@@ -3616,7 +3919,7 @@ double HardcodedConditions::GetMuonTriggerXSF2017(double leppt, double lepeta)
 
 }
 
-double HardcodedConditions::GetMuonTriggerXSF2018(double leppt, double lepeta)
+double HardcodedConditions::GetMuonTriggerVlqXSF2018(double leppt, double lepeta)
 {
 	float triggSF = 1.0;
 	float triggSFUncert = 1.0;
@@ -3663,6 +3966,294 @@ double HardcodedConditions::GetMuonTriggerXSF2018(double leppt, double lepeta)
 
 	return triggSF;
 }
+
+
+/*.-----------------------------------------------------------------.
+  /  .-.                                                         .-.  \
+ |  /   \                                                       /   \  |
+ | |\_.  |                                                     |    /| |
+ |\|  | /|          MUON TRIGGER SCALE FACTOR SECTION          |\  | |/|
+ | `---' |                    (from Nikos)                     | `---' |
+ |       |                                                     |       |
+ |       |-----------------------------------------------------|       |
+ \       |                                                     |       /
+  \     /                                                       \     /
+   `---'                                                         `---'*/
+
+double HardcodedConditions::GetMuonTriggerXSF(double pt, double eta, int year)
+{
+  //The main getter for Muon Trigger Scale Factors
+  if      (year==2016) return GetMuonTriggerXSF2016(pt, eta);
+  else if (year==2017) return GetMuonTriggerXSF2017(pt, eta);
+  else if (year==2018) return GetMuonTriggerXSF2018(pt, eta);
+  else return 0. ;
+}//end GetMuonTriggerXSF
+
+double HardcodedConditions::GetMuonTriggerXSF2016(double pt, double eta)
+{
+	// TO-BE-IMPLEMENTED!!!!!!!
+	return 1.000 ;
+
+}
+
+double HardcodedConditions::GetMuonTriggerXSF2017(double leppt, double lepeta)
+{
+	  float triggerSFB = 1.0;
+	  float triggerSFCDEF = 1.0;
+	  float triggerSFBunc = 0.0;
+	  float triggerSFCDEFunc = 0.0;
+	  if (fabs(lepeta) < 0.90){
+		if (leppt >=20.0 &&  leppt< 25.0 ) {
+		    triggerSFB=0.10901424368; triggerSFBunc=0.0297520484758;
+            triggerSFCDEF=1.0052069587; triggerSFCDEFunc=0.0026600686695;
+		    }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {
+            triggerSFB=0.0210210903521; triggerSFBunc=0.00735762154869;
+            triggerSFCDEF=0.960995864882; triggerSFCDEFunc=0.00500791874781;
+            }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {
+            triggerSFB=0.0242333358365; triggerSFBunc=0.00757259539495;
+            triggerSFCDEF=0.974505384769; triggerSFCDEFunc=0.003957690118;
+            }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {
+            triggerSFB=0.0364588464917; triggerSFBunc=0.00924488272953;
+            triggerSFCDEF=0.983399145478; triggerSFCDEFunc=0.0036271475697;
+            }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {
+            triggerSFB=0.0155568004374; triggerSFBunc=0.00630250726765;
+            triggerSFCDEF=0.988333635773; triggerSFCDEFunc=0.0033581107186;
+            }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {
+            triggerSFB=0.0601735535178; triggerSFBunc=0.0127378687507;
+            triggerSFCDEF=0.992949384645; triggerSFCDEFunc=0.00318012878697;
+            }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {
+            triggerSFB=0.957992262221; triggerSFBunc=0.00904323273559;
+            triggerSFCDEF=1.01031349539; triggerSFCDEFunc=0.000642798495817;
+            }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {
+            triggerSFB=1.01130851753; triggerSFBunc=0.000512750896517;
+            triggerSFCDEF=1.01130851753; triggerSFCDEFunc=0.000512750896517;
+            }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {
+            triggerSFB=1.00991777123; triggerSFBunc=0.000970190328605;
+            triggerSFCDEF=1.01036170337; triggerSFCDEFunc=0.000413700942763;
+            }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {
+            triggerSFB=1.0108606672; triggerSFBunc=0.000911109504948;
+            triggerSFCDEF=1.00777390206; triggerSFCDEFunc=0.000720296322595;
+            }
+        else {
+            triggerSFB=1.01283446282; triggerSFBunc=0.000745881092977;
+            triggerSFCDEF=1.00696862616; triggerSFCDEFunc=0.00184408341266;
+            }
+	  }
+	  else if (fabs(lepeta) < 1.20){
+	    if (leppt >=20.0 &&  leppt< 25.0 ) {
+	        triggerSFB=0.0662842747267; triggerSFBunc=0.0453330771566;
+            triggerSFCDEF=1.01637074529; triggerSFCDEFunc=0.00393276265789;
+	        }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {
+            triggerSFB=0.0226119816607; triggerSFBunc=0.0158144284011;
+            triggerSFCDEF=0.975331610131; triggerSFCDEFunc=0.00818431789788;
+            }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {
+            triggerSFB=0.0690721943662; triggerSFBunc=0.0252132107011;
+            triggerSFCDEF=0.969696033218; triggerSFCDEFunc=0.00786836176121;
+            }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {
+            triggerSFB=0.0184541200508; triggerSFBunc=0.0129309814826;
+            triggerSFCDEF=0.999875784844; triggerSFCDEFunc=0.00565894518267;
+            }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {
+            triggerSFB=0.00987116596908; triggerSFBunc=0.00982314053155;
+            triggerSFCDEF=0.972470985489; triggerSFCDEFunc=0.00734148819756;
+            }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {
+            triggerSFB=0.0912843448139; triggerSFBunc=0.0329179690396;
+            triggerSFCDEF=0.995205263009; triggerSFCDEFunc=0.00563888825035;
+            }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {
+            triggerSFB=0.931375691137; triggerSFBunc=0.0213959361471;
+            triggerSFCDEF=1.0060230931; triggerSFCDEFunc=0.00160633294093;
+            }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {
+            triggerSFB=0.987840495689; triggerSFBunc=0.0121230178352;
+            triggerSFCDEF=1.00900850631; triggerSFCDEFunc=0.000878347086976;
+            }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {
+            triggerSFB=0.997989070224; triggerSFBunc=0.00729585751033;
+            triggerSFCDEF=1.00992616194; triggerSFCDEFunc=0.00164676851791;
+            }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {
+            triggerSFB=0.987291487084; triggerSFBunc=0.00865733825407;
+            triggerSFCDEF=0.997323789347; triggerSFCDEFunc=0.00229167095156;
+            }
+        else {
+            triggerSFB=1.01043951474; triggerSFBunc=0.00142459194722;
+            triggerSFCDEF=1.01043951474; triggerSFCDEFunc=0.00142459194722;
+            }
+	  }
+	  else if (fabs(lepeta) < 2.0){
+	    if (leppt >=20.0 &&  leppt< 25.0 ) {
+	        triggerSFB=0.121788408593; triggerSFBunc=0.0404492057733;
+            triggerSFCDEF=1.00901933462; triggerSFCDEFunc=0.00522124464452;
+	        }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {
+            triggerSFB=0.0212654325135; triggerSFBunc=0.010525396768;
+            triggerSFCDEF=0.981013066271; triggerSFCDEFunc=0.00655696986969;
+            }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {
+            triggerSFB=0.0283166962203; triggerSFBunc=0.0124904631503;
+            triggerSFCDEF=0.98580551783; triggerSFCDEFunc=0.0058122300255;
+            }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {
+            triggerSFB=0.0205248452988; triggerSFBunc=0.0101603667217;
+            triggerSFCDEF=1.00222957851; triggerSFCDEFunc=0.00489449557235;
+            }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {
+            triggerSFB=0.0243099947572; triggerSFBunc=0.0120112097715;
+            triggerSFCDEF=0.995440124982; triggerSFCDEFunc=0.0054771344018;
+            }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {
+            triggerSFB=0.131546794772; triggerSFBunc=0.025617977044;
+            triggerSFCDEF=1.00512489719; triggerSFCDEFunc=0.00475681380405;
+            }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {
+            triggerSFB=0.935871664822; triggerSFBunc=0.0169195527249;
+            triggerSFCDEF=1.01761118339; triggerSFCDEFunc=0.00113936544648;
+            }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {
+            triggerSFB=0.999506866986; triggerSFBunc=0.00838698960941;
+            triggerSFCDEF=1.0134981693; triggerSFCDEFunc=0.00103420313813;
+            }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {
+            triggerSFB=1.00763676579; triggerSFBunc=0.00382256649265;
+            triggerSFCDEF=1.01163709462; triggerSFCDEFunc=0.00114370618974;
+            }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {
+            triggerSFB=1.00830247462; triggerSFBunc=0.00383384346238;
+            triggerSFCDEF=1.00495678228; triggerSFCDEFunc=0.00175352328092;
+            }
+        else {
+            triggerSFB=0.997308629862; triggerSFBunc=0.0155221884374;
+            triggerSFCDEF=1.00620582422; triggerSFCDEFunc=0.00360278358703;
+            }
+	  }
+	  else{
+         if (leppt >=20.0 &&  leppt< 25.0 ) {
+            triggerSFB=0.121788408593; triggerSFBunc=0.0404492057733;
+            triggerSFCDEF=1.00901933462; triggerSFCDEFunc=0.00522124464452;
+            }
+         else if (leppt >=25.0 &&  leppt< 30.0 ) {
+            triggerSFB=0.0212654325135; triggerSFBunc=0.010525396768;
+            triggerSFCDEF=0.981013066271; triggerSFCDEFunc=0.00655696986969;
+            }
+         else if (leppt >=30.0 &&  leppt< 35.0 ) {
+            triggerSFB=0.0283166962203; triggerSFBunc=0.0124904631503;
+            triggerSFCDEF=0.98580551783; triggerSFCDEFunc=0.0058122300255;
+            }
+         else if (leppt >=35.0 &&  leppt< 40.0 ) {
+            triggerSFB=0.0205248452988; triggerSFBunc=0.0101603667217;
+            triggerSFCDEF=1.00222957851; triggerSFCDEFunc=0.00489449557235;
+            }
+         else if (leppt >=40.0 &&  leppt< 45.0 ) {
+            triggerSFB=0.0243099947572; triggerSFBunc=0.0120112097715;
+            triggerSFCDEF=0.995440124982; triggerSFCDEFunc=0.0054771344018;
+            }
+         else if (leppt >=45.0 &&  leppt< 50.0 ) {
+            triggerSFB=0.131546794772; triggerSFBunc=0.025617977044;
+            triggerSFCDEF=1.00512489719; triggerSFCDEFunc=0.00475681380405;
+            }
+         else if (leppt >=50.0 &&  leppt< 60.0 ) {
+            triggerSFB=0.935871664822; triggerSFBunc=0.0169195527249;
+            triggerSFCDEF=1.01761118339; triggerSFCDEFunc=0.00113936544648;
+            }
+         else if (leppt >=60.0 &&  leppt< 70.0 ) {
+            triggerSFB=0.999506866986; triggerSFBunc=0.00838698960941;
+            triggerSFCDEF=1.0134981693; triggerSFCDEFunc=0.00103420313813;
+            }
+         else if (leppt >=70.0 &&  leppt< 100.0 ) {
+            triggerSFB=1.00763676579; triggerSFBunc=0.00382256649265;
+            triggerSFCDEF=1.01163709462; triggerSFCDEFunc=0.00114370618974;
+            }
+         else if (leppt >=100.0 &&  leppt< 200.0 ) {
+            triggerSFB=1.00830247462; triggerSFBunc=0.00383384346238;
+            triggerSFCDEF=1.00495678228; triggerSFCDEFunc=0.00175352328092;
+            }
+         else {
+            triggerSFB=0.997308629862; triggerSFBunc=0.0155221884374;
+            triggerSFCDEF=1.00620582422; triggerSFCDEFunc=0.00360278358703;
+            }
+	  }
+	  float triggerSF = (4.823*triggerSFB+36.734*triggerSFCDEF)/41.557;
+	  float triggerSFUncert = sqrt( pow(4.823*triggerSFBunc/41.557,2) + pow(36.734*triggerSFCDEFunc/41.557,2) );
+
+	return triggerSF;
+
+}
+
+double HardcodedConditions::GetMuonTriggerXSF2018(double leppt, double lepeta)
+{
+	float triggerSF18 = 1.0;
+	float triggerSF18Uncert = 1.0;
+	if (fabs(lepeta) < 0.9){
+		if (leppt >=20.0 &&  leppt< 25.0 ) {triggerSF18=0.987417939948; triggerSF18Uncert=0.00251362731945; }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {triggerSF18=0.917141370412; triggerSF18Uncert=0.00429435321593; }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {triggerSF18=0.946444021444; triggerSF18Uncert=0.00340050502629; }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {triggerSF18=0.966553376455; triggerSF18Uncert=0.002971455577; }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {triggerSF18=0.970691584144; triggerSF18Uncert=0.00293105430144; }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {triggerSF18=0.983126243357; triggerSF18Uncert=0.00260347852603; }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {triggerSF18=1.00830171939; triggerSF18Uncert=0.000553130869919; }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {triggerSF18=1.00797984647; triggerSF18Uncert=0.000683459180841; }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {triggerSF18=1.00823278299; triggerSF18Uncert=0.00044400015482; }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {triggerSF18=1.0056714938; triggerSF18Uncert=0.00057478904892; }
+        else {triggerSF18=1.00711097369; triggerSF18Uncert=0.0013107920744; }
+	  }
+	else if (fabs(lepeta) < 1.2){
+        if (leppt >=20.0 &&  leppt< 25.0 ) {triggerSF18=0.976441901891; triggerSF18Uncert=0.00490331927403; }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {triggerSF18=0.946751382153; triggerSF18Uncert=0.00670382249721; }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {triggerSF18=0.962123712952; triggerSF18Uncert=0.00561105901647; }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {triggerSF18=0.969840528002; triggerSF18Uncert=0.00527517900409; }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {triggerSF18=0.963741770557; triggerSF18Uncert=0.00575801824799; }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {triggerSF18=0.974243421361; triggerSF18Uncert=0.00494357669008; }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {triggerSF18=1.00335772265; triggerSF18Uncert=0.000818561291688; }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {triggerSF18=1.00459639791; triggerSF18Uncert=0.000851333503311; }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {triggerSF18=1.00353653555; triggerSF18Uncert=0.00046503525718; }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {triggerSF18=1.00304760188; triggerSF18Uncert=0.000778596944384; }
+        else  {triggerSF18=0.999234385181; triggerSF18Uncert=0.00273653748279; }
+	  }
+	else if (fabs(lepeta) < 2.0){
+	    if (leppt >=20.0 &&  leppt< 25.0 ) {triggerSF18=0.991590058833; triggerSF18Uncert=0.00351725974429; }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {triggerSF18=0.916031418308; triggerSF18Uncert=0.00543097323382; }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {triggerSF18=0.958609376918; triggerSF18Uncert=0.00439944564197; }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {triggerSF18=0.97337282064; triggerSF18Uncert=0.00398436515741; }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {triggerSF18=0.97295186263; triggerSF18Uncert=0.00417315471136; }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {triggerSF18=0.98893432467; triggerSF18Uncert=0.00351110170968; }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {triggerSF18=1.00830673332; triggerSF18Uncert=0.000720108711652; }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {triggerSF18=1.00640337992; triggerSF18Uncert=0.000926568415299; }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {triggerSF18=1.00928008959; triggerSF18Uncert=0.00136812990457; }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {triggerSF18=1.00704811071; triggerSF18Uncert=0.000851600138819; }
+        else  {triggerSF18=1.00360554222; triggerSF18Uncert=0.00159942722987; }
+	  }
+	else{
+        if (leppt >=20.0 &&  leppt< 25.0 ) {triggerSF18=0.991590058833; triggerSF18Uncert=0.00351725974429; }
+        else if (leppt >=25.0 &&  leppt< 30.0 ) {triggerSF18=0.916031418308; triggerSF18Uncert=0.00543097323382; }
+        else if (leppt >=30.0 &&  leppt< 35.0 ) {triggerSF18=0.958609376918; triggerSF18Uncert=0.00439944564197; }
+        else if (leppt >=35.0 &&  leppt< 40.0 ) {triggerSF18=0.97337282064; triggerSF18Uncert=0.00398436515741; }
+        else if (leppt >=40.0 &&  leppt< 45.0 ) {triggerSF18=0.97295186263; triggerSF18Uncert=0.00417315471136; }
+        else if (leppt >=45.0 &&  leppt< 50.0 ) {triggerSF18=0.98893432467; triggerSF18Uncert=0.00351110170968; }
+        else if (leppt >=50.0 &&  leppt< 60.0 ) {triggerSF18=1.00830673332; triggerSF18Uncert=0.000720108711652; }
+        else if (leppt >=60.0 &&  leppt< 70.0 ) {triggerSF18=1.00640337992; triggerSF18Uncert=0.000926568415299; }
+        else if (leppt >=70.0 &&  leppt< 100.0 ) {triggerSF18=1.00928008959; triggerSF18Uncert=0.00136812990457; }
+        else if (leppt >=100.0 &&  leppt< 200.0 ) {triggerSF18=1.00704811071; triggerSF18Uncert=0.000851600138819; }
+        else {triggerSF18=1.00360554222; triggerSF18Uncert=0.00159942722987; }
+	 }
+
+	return triggerSF18;
+}
+
+
 
 
 /*.-----------------------------------------------------------------.

--- a/step1/HardcodedConditions.h
+++ b/step1/HardcodedConditions.h
@@ -19,10 +19,12 @@ public:
     double GetElectronIdSF(double pt, double eta, int year = 2017);
     double GetElectronIsoSF(double pt, double eta, int year = 2017);
     double GetElectronTriggerSF(double pt, double eta, int year = 2017);
+    double GetIsEHadronTriggerSF(double njets, double ht, int year = 2017);
     double GetElectronTriggerXSF(double pt, double eta, int year = 2017);
     double GetMuonIdSF(double pt, double eta, int year = 2017);
     double GetMuonIsoSF(double pt, double eta, int year = 2017);
     double GetMuonTriggerSF(double pt, double eta, int year = 2017);
+    double GetIsMHadronTriggerSF(double njets, double ht, int year = 2017);
     double GetMuonTriggerXSF(double pt, double eta, int year = 2017);
 
     void GetBtaggingSF(double pt, double eta, double *btagsf, double *btagsfunc, std::string tagger="CSVM", int jetHFlav = 5, int year = 2017);
@@ -56,6 +58,10 @@ private:
     double GetElectronTriggerSF2017(double pt, double eta);
     double GetElectronTriggerSF2018(double pt, double eta);
 
+    double GetIsEHadronTriggerSF2016(double njets, double ht);
+    double GetIsEHadronTriggerSF2017(double njets, double ht);
+    double GetIsEHadronTriggerSF2018(double njets, double ht);
+
     double GetElectronTriggerXSF2016(double pt, double eta);
     double GetElectronTriggerXSF2017(double pt, double eta);
     double GetElectronTriggerXSF2018(double pt, double eta);
@@ -67,6 +73,10 @@ private:
     double GetMuonIsoSF2016(double pt, double eta);
     double GetMuonIsoSF2017(double pt, double eta);
     double GetMuonIsoSF2018(double pt, double eta);
+
+    double GetIsMHadronTriggerSF2016(double njets, double ht);
+    double GetIsMHadronTriggerSF2017(double njets, double ht);
+    double GetIsMHadronTriggerSF2018(double njets, double ht);
 
     double GetMuonTriggerSF2016(double pt, double eta);
     double GetMuonTriggerSF2017(double pt, double eta);

--- a/step1/HardcodedConditions.h
+++ b/step1/HardcodedConditions.h
@@ -21,11 +21,13 @@ public:
     double GetElectronTriggerSF(double pt, double eta, int year = 2017);
     double GetIsEHadronTriggerSF(double njets, double ht, int year = 2017);
     double GetElectronTriggerXSF(double pt, double eta, int year = 2017);
+    double GetElectronTriggerVlqXSF(double pt, double eta, int year = 2017);
     double GetMuonIdSF(double pt, double eta, int year = 2017);
     double GetMuonIsoSF(double pt, double eta, int year = 2017);
     double GetMuonTriggerSF(double pt, double eta, int year = 2017);
     double GetIsMHadronTriggerSF(double njets, double ht, int year = 2017);
     double GetMuonTriggerXSF(double pt, double eta, int year = 2017);
+    double GetMuonTriggerVlqXSF(double pt, double eta, int year = 2017);
 
     void GetBtaggingSF(double pt, double eta, double *btagsf, double *btagsfunc, std::string tagger="CSVM", int jetHFlav = 5, int year = 2017);
     void GetBtaggingEff(double pt, double *eff, std::string tagger="CSVM", int jetHFlav = 5, int year = 2017);
@@ -66,6 +68,10 @@ private:
     double GetElectronTriggerXSF2017(double pt, double eta);
     double GetElectronTriggerXSF2018(double pt, double eta);
 
+    double GetElectronTriggerVlqXSF2016(double pt, double eta);
+    double GetElectronTriggerVlqXSF2017(double pt, double eta);
+    double GetElectronTriggerVlqXSF2018(double pt, double eta);
+
     double GetMuonIdSF2016(double pt, double eta);
     double GetMuonIdSF2017(double pt, double eta);
     double GetMuonIdSF2018(double pt, double eta);
@@ -85,6 +91,10 @@ private:
     double GetMuonTriggerXSF2016(double pt, double eta);
     double GetMuonTriggerXSF2017(double pt, double eta);
     double GetMuonTriggerXSF2018(double pt, double eta);
+
+    double GetMuonTriggerVlqXSF2016(double pt, double eta);
+    double GetMuonTriggerVlqXSF2017(double pt, double eta);
+    double GetMuonTriggerVlqXSF2018(double pt, double eta);
 
     void GetBtaggingSF2016(double pt, double eta, double *btagsf, double *btagsfunc, std::string tagger="CSVM");
     void GetCtaggingSF2016(double pt, double eta, double *btagsf, double *btagsfunc, std::string tagger="CSVM");

--- a/step1/README.md
+++ b/step1/README.md
@@ -1,0 +1,43 @@
+## Quick Structure Explanation
+* `hadd.sh` calls `haddoutput.py` which is newer than  `haddoutputbrux.py`
+    * `haddoutput.py` runs hadd for list of files
+
+* `compileStep1.C` loads `step1.cc` and `HardcodedConditions.cc`
+* `makeStep1.C` macro for running `step1.cc` event loop for shifts (nominal, JEC/R up/down) and all
+    files given as argument
+* `makeStep1.sh` shell to actually run `makeStep1.C` with arguments
+
+* `submitSlimmerJobs.sh` runs `submitCondorSlimmerJobs.py` for all the different shifts
+*  `runCondorSLimmerJobs.py` creates files to submit to condor and then submits them to HTCondor
+
+*  `submitQsubSlimmerJobs.sh` runs `submitQsubSlimmerJobs.py` for all the different shifts
+*  `runQsubSlimmerJobs.py` creates big .txt files with qsub commands to submit to qsub batch system
+
+
+## What to run for :
+  ### Condor (BRU or lxplus or UoB):
+   ``` 
+        condor_submit <file> 
+   ```
+   For multiple condor jobsrun `runCondorSlimmerJobs.py`
+   To submit all jobs for all the shifts, run:
+   ```
+        source submitSlimmerJobs
+   ```
+   
+   
+  ### Qsub (VUB):
+  ```
+        qsub -q localgrid -v LIST=of,CMD=line,ARGUMENTS=for <File.sh>
+   ```
+   `<Files.sh>` sets the environment, copies over the needed files and runs a python script in a
+   `$TMPDIR`
+   To run many qsub commands run:
+    ```
+        source   submitQsubSlimmerJobs.sh
+    ```
+    to produce a txt file and run:
+   ```
+        bigsubmission fileWithQsubCommands.txt
+   ```
+  

--- a/step1/makeStep1.sh
+++ b/step1/makeStep1.sh
@@ -56,12 +56,16 @@ for SHIFT in nominal JECup JECdown JERup JERdown
   do
   haddFile=${outfilename}_${ID}${SHIFT}_hadd.root
   hadd ${haddFile} *${SHIFT}.root
-  echo "xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/}"
-  xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/} 2>&1
+  # echo "xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/}"
+  #xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/} 2>&1
+
+  echo "gfal-copy -f file://$TMPDIR/${haddFile} srm://maite.iihe.ac.be:8443/pnfs/iihe/cms/store/user/$USER/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/${haddFile}"
+  gfal-copy -f file://$TMPDIR/${haddFile} srm://maite.iihe.ac.be:8443/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/} 2>&1
+
   XRDEXIT=$?
   if [[ $XRDEXIT -ne 0 ]]; then
     rm *.root
-    echo "exit code $XRDEXIT, failure in xrdcp"
+    echo "exit code $XRDEXIT, failure in xrdcp (or gfal-copy)"
     exit $XRDEXIT
   fi
   rm *${SHIFT}.root

--- a/step1/makeStep1.sh
+++ b/step1/makeStep1.sh
@@ -59,7 +59,7 @@ for SHIFT in nominal JECup JECdown JERup JERdown
   # echo "xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/}"
   #xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/} 2>&1
 
-  echo "gfal-copy -f file://$TMPDIR/${haddFile} srm://maite.iihe.ac.be:8443/pnfs/iihe/cms/store/user/$USER/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/${haddFile}"
+  echo "gfal-copy -f file://$TMPDIR/${haddFile} srm://maite.iihe.ac.be:8443/pnfs/iihe/cms/store/user/$USER/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/}"
   gfal-copy -f file://$TMPDIR/${haddFile} srm://maite.iihe.ac.be:8443/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/} 2>&1
 
   XRDEXIT=$?

--- a/step1/resubmitFailedJobs.py
+++ b/step1/resubmitFailedJobs.py
@@ -6,7 +6,7 @@ inputDir = '/uscms_data/d3/ssagir/FWLJMET102X_1lep2018_Oct2019_4t_031520_step1/'
 resubmit_err = False
 resubmit_out = False
 resubmit_fail = False
-resubmit_running = False #Make sure you know what you are doing with this option!
+resubmit_running = False  # Make sure you know what you are doing with this option!
 resubmit = False
 
 samplesDone = []

--- a/step1/runQsubSlimmerJobs.py
+++ b/step1/runQsubSlimmerJobs.py
@@ -1,0 +1,292 @@
+import os,shutil,datetime,time
+import getpass
+from ROOT import *
+from XRootD import client
+xrdClient = client.FileSystem("root://brux11.hep.brown.edu:1094/")
+execfile("/uscms_data/d3/jmanagan/EOSSafeUtils.py")
+
+start_time = time.time()
+
+#IO directories must be full paths
+
+Year = 2017  # or 2018
+finalStateYear = 'singleLep'+str(Year)
+inputDir='/eos/uscms/store/user/lpcljm/FWLJMET102X_1lep'+str(Year)+'_Oct2019/'  # or 2018
+#inputDir='/isilon/hadoop/store/group/bruxljm/FWLJMET102X_1lep'+str(Year)+'_Oct2019/' # or 2018
+outputDir='/pnfs/iihe/cms/store/user/$USER/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_031520_step1/nominal/'
+    #'/eos/uscms/store/user/ssagir/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_031520_step1/nominal/'  # or 2018
+condorDir='/uscms_data/d3/ssagir/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_031520_step1/'  # or 2018
+shifts = ['JECup','JECdown','JERup','JERdown']
+inputLoc='lpc'
+if inputDir.startswith('/isilon/hadoop/'): inputLoc='brux'
+
+runDir=os.getcwd()
+inDir=inputDir[10:]
+if inputLoc=='brux': inDir=inputDir
+outDir=outputDir[10:]
+
+gROOT.ProcessLine('.x compileStep1.C')
+
+print 'Starting submission'
+count=0
+
+dirList17 = [
+'DYJetsToLL_M-50_HT-1200to2500_TuneCP5_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-2500toInf_TuneCP5_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-800to1200_TuneCP5_13TeV-madgraphMLM-pythia8',
+'QCD_HT1000to1500_TuneCP5_13TeV-madgraph-pythia8',
+'QCD_HT1500to2000_TuneCP5_13TeV-madgraph-pythia8',
+'QCD_HT2000toInf_TuneCP5_13TeV-madgraph-pythia8',
+'QCD_HT200to300_TuneCP5_13TeV-madgraph-pythia8',
+'QCD_HT300to500_TuneCP5_13TeV-madgraph-pythia8',
+'QCD_HT500to700_TuneCP5_13TeV-madgraph-pythia8',
+'QCD_HT700to1000_TuneCP5_13TeV-madgraph-pythia8',
+'ST_s-channel_antitop_leptonDecays_13TeV-PSweights_powheg-pythia',
+'ST_s-channel_top_leptonDecays_13TeV-PSweights_powheg-pythia',
+'ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'ST_t-channel_top_4f_InclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'ST_tW_antitop_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'ST_tW_top_5f_inclusiveDecays_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'JetHT',
+'SingleElectron',
+'SingleMuon',
+'TTHH_TuneCP5_13TeV-madgraph-pythia8',
+'TTTJ_TuneCP5_13TeV-madgraph-pythia8',
+'TTTT_TuneCP5_PSweights_13TeV-amcatnlo-pythia8',
+'TTTW_TuneCP5_13TeV-madgraph-pythia8',
+'TTTo2L2Nu_TuneCP5_PSweights_13TeV-powheg-pythia8',
+# 'TTTo2L2Nu_TuneCP5_erdON_13TeV-powheg-pythia8',
+'TTTo2L2Nu_TuneCP5down_PSweights_13TeV-powheg-pythia8',
+'TTTo2L2Nu_TuneCP5up_PSweights_13TeV-powheg-pythia8',
+'TTTo2L2Nu_hdampDOWN_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'TTTo2L2Nu_hdampUP_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'TTToHadronic_TuneCP5_PSweights_13TeV-powheg-pythia8',
+# 'TTToHadronic_TuneCP5_erdON_13TeV-powheg-pythia8',
+'TTToHadronic_TuneCP5down_PSweights_13TeV-powheg-pythia8',
+'TTToHadronic_TuneCP5up_PSweights_13TeV-powheg-pythia8',
+'TTToHadronic_hdampDOWN_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'TTToHadronic_hdampUP_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'TTToSemiLepton_HT500Njet9_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_TuneCP5_PSweights_13TeV-powheg-pythia8',
+# 'TTToSemiLeptonic_TuneCP5_erdON_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_TuneCP5down_PSweights_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_TuneCP5up_PSweights_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_hdampDOWN_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_hdampUP_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'TTWH_TuneCP5_13TeV-madgraph-pythia8',
+'TTWJetsToLNu_TuneCP5_PSweights_13TeV-amcatnloFXFX-madspin-pythia8',
+'TTWW_TuneCP5_13TeV-madgraph-pythia8',
+'TTWZ_TuneCP5_13TeV-madgraph-pythia8',
+'TTZH_TuneCP5_13TeV-madgraph-pythia8',
+'TTZToLLNuNu_M-10_TuneCP5_PSweights_13TeV-amcatnlo-pythia8',
+'TTZToLL_M-1to10_TuneCP5_13TeV-amcatnlo-pythia8',
+'TTZZ_TuneCP5_13TeV-madgraph-pythia8',
+# 'TT_Mtt-1000toInf_TuneCP5_PSweights_13TeV-powheg-pythia8',
+# 'TT_Mtt-700to1000_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WW_TuneCP5_13TeV-pythia8',
+'WZ_TuneCP5_13TeV-pythia8',
+'ZZ_TuneCP5_13TeV-pythia8',
+'ttHToNonbb_M125_TuneCP5_13TeV-powheg-pythia8',
+'ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8',
+]
+
+dirList18lpc = [
+'DYJetsToLL_M-50_HT-1200to2500_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-200to400_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-2500toInf_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-400to600_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-600to800_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8',
+'DYJetsToLL_M-50_HT-800to1200_TuneCP5_PSweights_13TeV-madgraphMLM-pythia8',
+'QCD_HT1000to1500_TuneCP5_13TeV-madgraphMLM-pythia8',
+'QCD_HT1500to2000_TuneCP5_13TeV-madgraphMLM-pythia8',
+'QCD_HT2000toInf_TuneCP5_13TeV-madgraphMLM-pythia8',
+'QCD_HT200to300_TuneCP5_13TeV-madgraphMLM-pythia8',
+'QCD_HT300to500_TuneCP5_13TeV-madgraphMLM-pythia8',
+'QCD_HT500to700_TuneCP5_13TeV-madgraphMLM-pythia8',
+'QCD_HT700to1000_TuneCP5_13TeV-madgraphMLM-pythia8',
+'ST_s-channel_4f_leptonDecays_TuneCP5_13TeV-madgraph-pythia8',
+'ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8',
+'ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8',
+'ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8',
+'ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8',
+'JetHT',
+'EGamma',
+'SingleMuon',
+'TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8',
+# 'TTTo2L2Nu_TuneCP5_erdON_13TeV-powheg-pythia8',
+'TTTo2L2Nu_TuneCP5down_13TeV-powheg-pythia8',
+'TTTo2L2Nu_hdampDOWN_TuneCP5_13TeV-powheg-pythia8',
+'TTTo2L2Nu_hdampUP_TuneCP5_13TeV-powheg-pythia8',
+'TTToHadronic_TuneCP5_13TeV-powheg-pythia8',
+# 'TTToHadronic_TuneCP5_erdON_13TeV-powheg-pythia8',
+'TTToHadronic_hdampDOWN_TuneCP5_13TeV-powheg-pythia8',
+'TTToHadronic_hdampUP_TuneCP5_13TeV-powheg-pythia8',
+'TTToSemiLepton_HT500Njet9_TuneCP5_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8',
+# 'TTToSemiLeptonic_TuneCP5_erdON_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_TuneCP5up_13TeV-powheg-pythia8',
+'TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8',
+'TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8',
+'TTZToLL_M-1to10_TuneCP5_13TeV-amcatnlo-pythia8',
+# 'TT_Mtt-1000toInf_TuneCP5_13TeV-powheg-pythia8',
+# 'TT_Mtt-700to1000_TuneCP5_PSweights_13TeV-powheg-pythia8',
+'WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8',
+'WW_TuneCP5_PSweights_13TeV-pythia8',
+'WZ_TuneCP5_PSweights_13TeV-pythia8',
+'ZZ_TuneCP5_13TeV-pythia8',
+'ttHToNonbb_M125_TuneCP5_13TeV-powheg-pythia8',
+'ttHTobb_M125_TuneCP5_13TeV-powheg-pythia8',
+]
+dirList18brux = [
+'TTHH_TuneCP5_13TeV-madgraph-pythia8',
+'TTTJ_TuneCP5_13TeV-madgraph-pythia8',
+'TTTT_TuneCP5_13TeV-amcatnlo-pythia8',
+'TTTW_TuneCP5_13TeV-madgraph-pythia8',
+'TTTo2L2Nu_TuneCP5up_13TeV-powheg-pythia8',
+'TTToHadronic_TuneCP5down_13TeV-powheg-pythia8',
+'TTToHadronic_TuneCP5up_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_TuneCP5down_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_hdampDOWN_TuneCP5_13TeV-powheg-pythia8',
+'TTToSemiLeptonic_hdampUP_TuneCP5_13TeV-powheg-pythia8',
+'TTWH_TuneCP5_13TeV-madgraph-pythia8',
+'TTWW_TuneCP5_13TeV-madgraph-pythia8',
+'TTWZ_TuneCP5_13TeV-madgraph-pythia8',
+'TTZH_TuneCP5_13TeV-madgraph-pythia8',
+'TTZZ_TuneCP5_13TeV-madgraph-pythia8',
+]
+
+dirList = dirList17[:]
+if Year==2018: 
+    dirList = dirList18lpc[:]
+    if inputLoc=='brux': dirList = dirList18brux[:]
+
+for sample in dirList:
+    print "------------ Sample:",sample,"---------------"
+    outList = ['none']
+    if 'Tprime' in sample: outList = ['BWBW','TZBW','THBW','TZTH','TZTZ','THTH']
+    elif 'Bprime' in sample: outList = ['TWTW','BZTW','BHTW','BZBH','BZBZ','BHBH']
+    elif 'TTToSemiLeptonic' in sample: outList = ['HT0Njet0','HT500Njet9']
+    #elif 'TTTo' in sample: outList = ['Mtt0to700','Mtt700to1000','Mtt1000toInf']
+    if 'TuneCP5down' in sample or 'TuneCP5up' in sample or 'hdampDOWN' in sample or 'hdampUP' in sample: outList = ['none']
+    if 'TTTo' in sample or 'TT_Mtt' in sample: 
+        if outList==['none']: outList = ['ttbb','ttcc','ttjj']
+        else:
+            outList_ = outList[:]
+            outList = []
+            for outlabel in outList_:
+                for flv in ['ttbb','ttcc','ttjj']: outList.append(outlabel+'_'+flv)
+
+    isData = False
+    if 'Single' in sample or 'EGamma' in sample or 'JetHT' in sample: isData = True
+
+    for outlabel in outList:
+        tmpcount = 0
+
+        outsample = sample+'_'+outlabel
+        if outlabel == 'none': outsample = sample
+
+        #os.system('eos root://cmseos.fnal.gov/ mkdir -p '+outDir+outsample)
+        #for shift in shifts: os.system('eos root://cmseos.fnal.gov/ mkdir -p '+outDir.replace('nominal',shift)+outsample)
+        os.system('mkdir -p '+condorDir+outsample)
+
+        #if inputLoc=='lpc':
+        #    runlist = EOSlistdir(inputDir+'/'+sample+'/'+finalStateYear+'/')
+        if inputLoc=='brux':
+            status, dirList = xrdClient.dirlist(inDir+'/'+sample+'/'+finalStateYear+'/')
+            runlist = [item.name for item in dirList]
+        print "Running",len(runlist),"crab directories"
+
+        for run in runlist:
+            #if inputLoc=='lpc':
+            #    numlist = EOSlistdir(inputDir+'/'+sample+'/'+finalStateYear+'/'+run+'/')
+            if inputLoc=='brux':
+                status, dirList = xrdClient.dirlist(inDir+'/'+sample+'/'+finalStateYear+'/'+run+'/')
+                numlist = [item.name for item in dirList]
+            
+            for num in numlist:
+                numpath = inputDir+'/'+sample+'/'+finalStateYear+'/'+run+'/'+num
+                pathsuffix = numpath.split('/')[-3:]
+                pathsuffix = '/'.join(pathsuffix)
+
+                #if inputLoc=='lpc':
+                #    rootfiles = EOSlist_root_files(numpath)
+                if inputLoc=='brux':
+                    status, fileList = xrdClient.dirlist(inDir+'/'+sample+'/'+finalStateYear+'/'+run+'/'+num+'/')
+                    rootfiles = [item.name for item in fileList if item.name.endswith('.root')]
+                basefilename = (rootfiles[0].split('.')[0]).split('_')[:-1]
+                basefilename = '_'.join(basefilename)
+                print "Running path:",pathsuffix,"\tBase filenames:",basefilename
+
+                nFilesPerJob=30
+                for i in range(0,len(rootfiles),nFilesPerJob):
+                    count+=1
+                    tmpcount += 1
+
+                    #if tmpcount > 1: continue
+
+                    segment1 = (rootfiles[i].split('.')[0]).split('_')[-1]  # 1-1
+                    segment2 = (rootfiles[i].split('.')[0]).split('_')[-2]  # SingleElectronRun2017C
+
+                    if isData:    # need unique IDs across eras
+                        idlist = segment2[-1]+segment1+' '
+                        for j in range(i+1,i+nFilesPerJob):
+                            if j >= len(rootfiles): continue
+                            idparts = (rootfiles[j].split('.')[0]).split('_')[-2:]
+                            idlist += idparts[0][-1]+idparts[1]+' '
+                    elif 'ext' in segment2:     # WON'T WORK in FWLJMET 052219, but ok since no samples need it
+                        idlist = segment2[-4:]+segment1+' '
+                        for j in range(i+1,i+nFilesPerJob):
+                            if j >= len(rootfiles): continue
+                            idparts = (rootfiles[j].split('.')[0]).split('_')[-2:]
+                            idlist += idparts[0][-4:]+idparts[1]+' '
+                    else:
+                        idlist = segment1+' '
+                        for j in range(i+1,i+nFilesPerJob):
+                            if j >= len(rootfiles): continue
+                            idlist += (rootfiles[j].split('.')[0]).split('_')[-1]+' '
+                        
+                    idlist = idlist.strip()
+                    print "Running IDs",idlist
+                
+                    dict={'RUNDIR':runDir, 'SAMPLE':sample, 'INPATHSUFFIX':pathsuffix, 'INPUTDIR':inDir, 'FILENAME':basefilename, 'OUTFILENAME':outsample, 'OUTPUTDIR':outDir, 'LIST':idlist, 'ID':tmpcount, 'YEAR':Year}
+                    jdfName=condorDir+'/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.sh' % dict
+                    print jdfName
+                    jdf=open(jdfName,'w')
+                    jdf.write(
+                        """#!/usr/bin/env bash
+#source $VO_CMS_SW_DIR/cmsset_default.sh
+# cd %(RUNDIR)s/   # /user/$USER/BrUFrame/CMSSW_10_2_16/src/
+# eval `scram runtime -sh`
+export X509_USER_PROXY=/user/$USER/x509up_u23075
+cd $TMPDIR
+cp %(RUNDIR)s/compileStep1.C .
+cp %(RUNDIR)s/makeStep1.C .
+cp %(RUNDIR)s/step1.cc .
+cp %(RUNDIR)s/step1.h .
+cp %(RUNDIR)s/HardcodedConditions.cc .
+cp %(RUNDIR)s/HardcodedConditions.h .
+cp %(RUNDIR)s/makeStep1.sh .
+source makeStep1.sh %(FILENAME)s %(OUTFILENAME)s %(INPUTDIR)s/%(SAMPLE)s/%(INPATHSUFFIX)s %(OUTPUTDIR)s/%(OUTFILENAME)s '%(LIST)s' %(ID)s %(YEAR)s""" % dict)
+                    jdf.close()
+                    os.chdir('%s/%s' % (condorDir,outsample))
+                    os.system('echo "qsub -q localgrid -o %(OUTFILENAME)s_%(ID)s.out -e %(OUTFILENAME)s_%(ID)s.err %(OUTFILENAME)s_%(ID)s.sh" >> job.txt' % dict)
+                    #os.system('condor_submit %(OUTFILENAME)s_%(ID)s.job' % dict)
+                    os.system('sleep 0.5')                                
+                    os.chdir('%s' % (runDir))
+                    print count, "jobs submitted!!!"
+        
+print("--- %s minutes ---" % (round(time.time() - start_time, 2)/60))

--- a/step1/runQsubSlimmerJobs.py
+++ b/step1/runQsubSlimmerJobs.py
@@ -2,8 +2,8 @@ import os,shutil,datetime,time
 import getpass
 from ROOT import *
 from XRootD import client
-xrdClient = client.FileSystem("root://brux11.hep.brown.edu:1094/")
-execfile("/uscms_data/d3/jmanagan/EOSSafeUtils.py")
+xrdClient = client.FileSystem("root://cmseos.fnal.gov/")
+#execfile("/uscms_data/d3/jmanagan/EOSSafeUtils.py")
 
 start_time = time.time()
 
@@ -15,9 +15,9 @@ inputDir='/eos/uscms/store/user/lpcljm/FWLJMET102X_1lep'+str(Year)+'_Oct2019/'  
 #inputDir='/isilon/hadoop/store/group/bruxljm/FWLJMET102X_1lep'+str(Year)+'_Oct2019/' # or 2018
 outputDir='/pnfs/iihe/cms/store/user/$USER/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_031520_step1/nominal/'
     #'/eos/uscms/store/user/ssagir/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_031520_step1/nominal/'  # or 2018
-condorDir='/uscms_data/d3/ssagir/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_031520_step1/'  # or 2018
+condorDir='/user/nistylia/BrUFrame/CMSSW_10_2_16/src/LJMet-Slimmer-4tops/step1/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_031520_step1/'  # or 2018
 shifts = ['JECup','JECdown','JERup','JERdown']
-inputLoc='lpc'
+inputLoc='brux'
 if inputDir.startswith('/isilon/hadoop/'): inputLoc='brux'
 
 runDir=os.getcwd()
@@ -207,6 +207,7 @@ for sample in dirList:
         #    runlist = EOSlistdir(inputDir+'/'+sample+'/'+finalStateYear+'/')
         if inputLoc=='brux':
             status, dirList = xrdClient.dirlist(inDir+'/'+sample+'/'+finalStateYear+'/')
+            print status
             runlist = [item.name for item in dirList]
         print "Running",len(runlist),"crab directories"
 
@@ -283,7 +284,7 @@ cp %(RUNDIR)s/makeStep1.sh .
 source makeStep1.sh %(FILENAME)s %(OUTFILENAME)s %(INPUTDIR)s/%(SAMPLE)s/%(INPATHSUFFIX)s %(OUTPUTDIR)s/%(OUTFILENAME)s '%(LIST)s' %(ID)s %(YEAR)s""" % dict)
                     jdf.close()
                     os.chdir('%s/%s' % (condorDir,outsample))
-                    os.system('echo "qsub -q localgrid -o %(OUTFILENAME)s_%(ID)s.out -e %(OUTFILENAME)s_%(ID)s.err %(OUTFILENAME)s_%(ID)s.sh" >> job.txt' % dict)
+                    os.system('echo "qsub -q localgrid -o %(OUTFILENAME)s_%(ID)s.out -e %(OUTFILENAME)s_%(ID)s.err %(OUTFILENAME)s_%(ID)s.sh" >> jobStep1All.txt' % dict)
                     #os.system('condor_submit %(OUTFILENAME)s_%(ID)s.job' % dict)
                     os.system('sleep 0.5')                                
                     os.chdir('%s' % (runDir))

--- a/step1/runQsubSlimmerJobs.py
+++ b/step1/runQsubSlimmerJobs.py
@@ -284,10 +284,11 @@ cp %(RUNDIR)s/makeStep1.sh .
 source makeStep1.sh %(FILENAME)s %(OUTFILENAME)s %(INPUTDIR)s/%(SAMPLE)s/%(INPATHSUFFIX)s %(OUTPUTDIR)s/%(OUTFILENAME)s '%(LIST)s' %(ID)s %(YEAR)s""" % dict)
                     jdf.close()
                     #os.chdir('%s/%s' % (condorDir,outsample))
-                    os.system('echo "qsub -q localgrid -o %(CONDORDIR)s/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.out -e %(CONDORDIR)s/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.err %(CONDORDIR)s/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.sh" >> jobStep1All.txt' % dict)
+                    os.system('echo "qsub -q localgrid -o %(CONDORDIR)s/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.out -e %(CONDORDIR)s/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.err %(CONDORDIR)s/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.sh" >> jobStep1All2.txt' % dict)
                     #os.system('condor_submit %(OUTFILENAME)s_%(ID)s.job' % dict)
                     os.system('sleep 0.5')                                
                     os.chdir('%s' % (runDir))
-                    print count, "jobs submitted!!!"
+                    print count, "job script created!!!"
+                    # print count, "jobs submitted!!!"
         
 print("--- %s minutes ---" % (round(time.time() - start_time, 2)/60))

--- a/step1/runQsubSlimmerJobs.py
+++ b/step1/runQsubSlimmerJobs.py
@@ -23,7 +23,7 @@ if inputDir.startswith('/isilon/hadoop/'): inputLoc='brux'
 runDir=os.getcwd()
 inDir=inputDir[10:]
 if inputLoc=='brux': inDir=inputDir
-outDir=outputDir[10:]
+outDir=outputDir
 
 gROOT.ProcessLine('.x compileStep1.C')
 
@@ -263,7 +263,7 @@ for sample in dirList:
                     idlist = idlist.strip()
                     print "Running IDs",idlist
                 
-                    dict={'RUNDIR':runDir, 'SAMPLE':sample, 'INPATHSUFFIX':pathsuffix, 'INPUTDIR':inDir, 'FILENAME':basefilename, 'OUTFILENAME':outsample, 'OUTPUTDIR':outDir, 'LIST':idlist, 'ID':tmpcount, 'YEAR':Year}
+                    dict={'RUNDIR':runDir, 'SAMPLE':sample, 'INPATHSUFFIX':pathsuffix, 'INPUTDIR':inDir, 'FILENAME':basefilename, 'OUTFILENAME':outsample, 'OUTPUTDIR':outDir, 'LIST':idlist, 'ID':tmpcount, 'YEAR':Year, "CONDORDIR":condorDir}
                     jdfName=condorDir+'/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.sh' % dict
                     print jdfName
                     jdf=open(jdfName,'w')
@@ -283,8 +283,8 @@ cp %(RUNDIR)s/HardcodedConditions.h .
 cp %(RUNDIR)s/makeStep1.sh .
 source makeStep1.sh %(FILENAME)s %(OUTFILENAME)s %(INPUTDIR)s/%(SAMPLE)s/%(INPATHSUFFIX)s %(OUTPUTDIR)s/%(OUTFILENAME)s '%(LIST)s' %(ID)s %(YEAR)s""" % dict)
                     jdf.close()
-                    os.chdir('%s/%s' % (condorDir,outsample))
-                    os.system('echo "qsub -q localgrid -o %(OUTFILENAME)s_%(ID)s.out -e %(OUTFILENAME)s_%(ID)s.err %(OUTFILENAME)s_%(ID)s.sh" >> jobStep1All.txt' % dict)
+                    #os.chdir('%s/%s' % (condorDir,outsample))
+                    os.system('echo "qsub -q localgrid -o %(CONDORDIR)s/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.out -e %(CONDORDIR)s/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.err %(CONDORDIR)s/%(OUTFILENAME)s/%(OUTFILENAME)s_%(ID)s.sh" >> jobStep1All.txt' % dict)
                     #os.system('condor_submit %(OUTFILENAME)s_%(ID)s.job' % dict)
                     os.system('sleep 0.5')                                
                     os.chdir('%s' % (runDir))

--- a/step1/step1.cc
+++ b/step1/step1.cc
@@ -459,6 +459,7 @@ void step1::Loop(TString inTreeName, TString outTreeName )
    outputTree->Branch("minMleppJet",&minMleppJet,"mixnMleppJet/F");
    outputTree->Branch("minDR_lepJet",&minDR_lepJet,"minDR_lepJet/F");
    outputTree->Branch("ptRel_lepJet",&ptRel_lepJet,"ptRel_lepJet/F");
+   outputTree->Branch("minDR_jetJets",&minDR_jetJets);
    outputTree->Branch("deltaR_lepJets",&deltaR_lepJets);
    outputTree->Branch("deltaR_lepBJets",&deltaR_lepBJets);
    outputTree->Branch("deltaR_lepBJets_bSFup",&deltaR_lepBJets_bSFup);
@@ -618,6 +619,7 @@ void step1::Loop(TString inTreeName, TString outTreeName )
 
    // Lorentz vectors
    TLorentzVector jet_lv;
+   TLorentzVector kjet_lv;
    TLorentzVector bjet_lv;
    TLorentzVector wjet1_lv;
    TLorentzVector tjet1_lv;
@@ -720,8 +722,8 @@ void step1::Loop(TString inTreeName, TString outTreeName )
       double genHT = 0;
       int Ngenjet = 0;
       for(unsigned int ijet=0; ijet < genJetPtNoClean_MultiLepCalc->size(); ijet++){
-	if(genJetPtNoClean_MultiLepCalc->at(ijet) > 30) Ngenjet+=1;
-	if(genJetPtNoClean_MultiLepCalc->at(ijet) > 30 && fabs(genJetEtaNoClean_MultiLepCalc->at(ijet)) < 2.4) genHT+=genJetPtNoClean_MultiLepCalc->at(ijet);
+	    if(genJetPtNoClean_MultiLepCalc->at(ijet) > 30) Ngenjet+=1;
+	    if(genJetPtNoClean_MultiLepCalc->at(ijet) > 30 && fabs(genJetEtaNoClean_MultiLepCalc->at(ijet)) < 2.4) genHT+=genJetPtNoClean_MultiLepCalc->at(ijet);
       }
       if(genHT>500 && Ngenjet>=9) {isHTgt500Njetge9 = 1;}
       }
@@ -840,15 +842,15 @@ void step1::Loop(TString inTreeName, TString outTreeName )
       mctriggers = {{"17B", {"Ele35_WPTight_Gsf", "IsoMu24_eta2p1" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
 		    {"17C",{"Ele35_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagCSV_2p2" }},
 		    {"17DEF",{"Ele32_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
-		    {"18",{"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT400_SixPFJet32_DoublePFBTagDeep_CSV_2p94" }}};
+		    {"18",{"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94" }}};
 
 
       std::map<TString, std::vector<std::string>> datatriggers;
       datatriggers = {{"17B", {"Ele35_WPTight_Gsf", "IsoMu24_eta2p1" , "PFHT380_SixJet32_DoubleBTagCSV_p075" }},
 		      {"17C",{"Ele35_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagCSV_2p2" }},
 		      {"17DEF",{"Ele32_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
-		      {"18AB", {"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT380_SixPFJet32_DoublePFBTagDeep_CSV_2p2" }},
-		      {"18CD",{"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT400_SixPFJet32_DoublePFBTagDeep_CSV_2p94" }}};
+		      {"18AB", {"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
+		      {"18CD",{"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94" }}};
       if (!isMC){
 	eltrigger = datatriggers.at(Era).at(0);
 	mutrigger =  datatriggers.at(Era).at(1);
@@ -991,10 +993,10 @@ void step1::Loop(TString inTreeName, TString outTreeName )
       HTSF_PolDn = 1;
 
       if(isMadgraphBkg){
-	// Piece-wise splice with a flat line. Uncertainty from upper/lower error bar fits
-	HTSF_Pol = poly2->Eval(HTfromHEPUEP_MultiLepCalc);
-	HTSF_PolUp = poly2U->Eval(HTfromHEPUEP_MultiLepCalc);
-	HTSF_PolDn = poly2D->Eval(HTfromHEPUEP_MultiLepCalc);
+	    // Piece-wise splice with a flat line. Uncertainty from upper/lower error bar fits
+	    HTSF_Pol = poly2->Eval(HTfromHEPUEP_MultiLepCalc);
+	    HTSF_PolUp = poly2U->Eval(HTfromHEPUEP_MultiLepCalc);
+	    HTSF_PolDn = poly2D->Eval(HTfromHEPUEP_MultiLepCalc);
       }
 
       // ----------------------------------------------------------------------------
@@ -1005,14 +1007,14 @@ void step1::Loop(TString inTreeName, TString outTreeName )
       double lepM;
       double lepphi;
       if (isMuon){ 
-	lepM = 0.105658367;
-	lepphi = muPhi_MultiLepCalc->at(0);
-	lepton_lv.SetPtEtaPhiM(muPt_MultiLepCalc->at(0),muEta_MultiLepCalc->at(0),muPhi_MultiLepCalc->at(0),lepM);
+	    lepM = 0.105658367;
+	    lepphi = muPhi_MultiLepCalc->at(0);
+	    lepton_lv.SetPtEtaPhiM(muPt_MultiLepCalc->at(0),muEta_MultiLepCalc->at(0),muPhi_MultiLepCalc->at(0),lepM);
       }
       else{
-	lepM = 0.00051099891;
-	lepphi = elPhi_MultiLepCalc->at(0);
-	lepton_lv.SetPtEtaPhiM(elPt_MultiLepCalc->at(0),elEta_MultiLepCalc->at(0),elPhi_MultiLepCalc->at(0),lepM);
+	    lepM = 0.00051099891;
+	    lepphi = elPhi_MultiLepCalc->at(0);
+	    lepton_lv.SetPtEtaPhiM(elPt_MultiLepCalc->at(0),elEta_MultiLepCalc->at(0),elPhi_MultiLepCalc->at(0),lepM);
       }      
 
       MT_lepMet = sqrt(2*leppt*corr_met_MultiLepCalc*(1 - cos(lepphi - corr_met_phi_MultiLepCalc)));
@@ -1259,6 +1261,7 @@ void step1::Loop(TString inTreeName, TString outTreeName )
       minDPhi_MetJet = 1e8;
       minDR_lepJet = 1e8;
       ptRel_lepJet = -99;
+      minDR_jetJets.clear();
       deltaR_lepJets.clear();
       deltaR_lepBJets.clear();
       deltaR_lepBJets_bSFup.clear();
@@ -1380,6 +1383,18 @@ void step1::Loop(TString inTreeName, TString outTreeName )
 	  minDR_lepJet = deltaR_lepJets[ijet];
 	  ptRel_lepJet = lepton_lv.P()*(jet_lv.Vect().Cross(lepton_lv.Vect()).Mag()/jet_lv.P()/lepton_lv.P());
 	}
+
+	minDR_jetJet = 1e8;
+	for(unsigned int kjet=0; kjet < theJetPt_JetSubCalc_PtOrdered.size(); kjet++){
+	    if(ijet == kjet){continue;}
+	    kjet_lv.SetPtEtaPhiE(theJetPt_JetSubCalc_PtOrdered.at(kjet),theJetEta_JetSubCalc_PtOrdered.at(kjet),theJetPhi_JetSubCalc_PtOrdered.at(kjet),theJetEnergy_JetSubCalc_PtOrdered.at(kjet));
+	    deltaR_jetJets = jet_lv.DeltaR(kjet_lv);
+	    if(deltaR_jetJets < minDR_jetJet) {
+	        minDR_jetJet = deltaR_jetJets;
+	    }
+	}
+	minDR_jetJets.push_back(minDR_jetJet);
+
       }
 
       // ----------------------------------------------------------------------------

--- a/step1/step1.cc
+++ b/step1/step1.cc
@@ -364,6 +364,7 @@ void step1::Loop(TString inTreeName, TString outTreeName )
    outputTree->Branch("EGammaGsfSF",&EGammaGsfSF,"EGammaGsfSF/F");
    outputTree->Branch("lepIdSF",&lepIdSF,"lepIdSF/F");
    outputTree->Branch("triggerSF",&triggerSF,"triggerSF/F");
+   outputTree->Branch("triggerHadSF",&triggerHadSF,"triggerHadSF/F");
    outputTree->Branch("triggerXSF",&triggerXSF,"triggerXSF/F");
    outputTree->Branch("isoSF",&isoSF,"isoSF/F");
    
@@ -790,201 +791,6 @@ void step1::Loop(TString inTreeName, TString outTreeName )
       }
 
       // ----------------------------------------------------------------------------
-      // Assign Lepton scale factor or efficiency weights, save trigger pass/fail
-      // ----------------------------------------------------------------------------
- 
-      // Triggers Initialised to ZERO
-      HLT_Ele15_IsoVVVL_PFHT450 = 0;
-      HLT_Ele28_eta2p1_WPTight_Gsf_HT150 = 0;
-      HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned = 0;
-      HLT_Mu15_IsoVVVL_PFHT450 = 0;
-      HLT_PFHT400_SixJet30_DoubleBTagCSV_p056 = 0;
-      HLT_Ele32_WPTight_Gsf = 0;
-      HLT_Ele35_WPTight_Gsf = 0;
-      HLT_IsoMu24 = 0;
-      HLT_IsoMu24_eta2p1 = 0;
-      HLT_IsoMu27 = 0;
-      HLT_PFHT380_SixJet32_DoubleBTagCSV_p075 = 0; // only data for 17B
-      HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2 = 0; // only MC for 17B
-      HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2 = 0;
-      HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94 = 0; // in 2018
-
-      DataPastTriggerX = 0;
-      MCPastTriggerX = 0;
-      DataPastTrigger = 0;
-      MCPastTrigger = 0;
-      DataLepPastTrigger = 0;
-      MCLepPastTrigger = 0;
-      DataHadPastTrigger = 0;
-      MCHadPastTrigger = 0;
-      EGammaGsfSF = 1.0;
-      lepIdSF = 1.0;
-      triggerSF = 1.0;
-      triggerXSF = 1.0;
-      isoSF = 1.0;
-      std::vector<std::string> eltriggersX;
-      std::vector<std::string> mutriggersX;
-      if(Year==2017){
-      eltriggersX = {"Ele15_IsoVVVL_PFHT450","Ele50_IsoVVVL_PFHT450","Ele15_IsoVVVL_PFHT600","Ele35_WPTight_Gsf","Ele38_WPTight_Gsf"};
-      mutriggersX = {"Mu15_IsoVVVL_PFHT450","Mu50_IsoVVVL_PFHT450","Mu15_IsoVVVL_PFHT600","Mu50"};
-      }
-      else if(Year==2018){
-      eltriggersX = {"Ele15_IsoVVVL_PFHT450","Ele50_IsoVVVL_PFHT450","Ele15_IsoVVVL_PFHT600","Ele35_WPTight_Gsf","Ele38_WPTight_Gsf","Ele15_IsoVVVL_PFHT450_PFMET50"};
-      mutriggersX = {"Mu15_IsoVVVL_PFHT450","Mu50_IsoVVVL_PFHT450","Mu15_IsoVVVL_PFHT600","Mu50","TkMu50","Mu15_IsoVVVL_PFHT450_PFMET50"};
-      }
-      std::string eltrigger;
-      std::string mutrigger;
-      std::string hadtrigger;
-      std::vector<std::string> eltriggers;
-      std::vector<std::string> mutriggers;
-      std::vector<std::string> hadtriggers;
-      std::map<TString, std::vector<std::string>> mctriggers;
-      mctriggers = {{"17B", {"Ele35_WPTight_Gsf", "IsoMu24_eta2p1" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
-		    {"17C",{"Ele35_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagCSV_2p2" }},
-		    {"17DEF",{"Ele32_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
-		    {"18",{"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94" }}};
-
-
-      std::map<TString, std::vector<std::string>> datatriggers;
-      datatriggers = {{"17B", {"Ele35_WPTight_Gsf", "IsoMu24_eta2p1" , "PFHT380_SixJet32_DoubleBTagCSV_p075" }},
-		      {"17C",{"Ele35_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagCSV_2p2" }},
-		      {"17DEF",{"Ele32_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
-		      {"18AB", {"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
-		      {"18CD",{"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94" }}};
-      if (!isMC){
-	eltrigger = datatriggers.at(Era).at(0);
-	mutrigger =  datatriggers.at(Era).at(1);
-	hadtrigger = datatriggers.at(Era).at(2);
-      }
-      else{
-	if (Year==2017){
-	  TRandom3 r;
-	  //TRandom3 *r = new TRandom3();
-	  float randLumi = r.Uniform(1.);    
-	  //Double_t randLumi = r->Rndm();
-	  TString Era17;
-	  float eraBupperLumi = (4.823/41.557);
-	  float eraCupperLumi = (14.487/41.557);
-	  if(randLumi>=0 && randLumi<= eraBupperLumi) Era17="17B";
-	  else if(randLumi>eraBupperLumi && randLumi<=eraCupperLumi) Era17="17C";
-	  else Era17="17DEF";
-	  eltrigger = mctriggers.at(Era17).at(0);
-	  mutrigger =  mctriggers.at(Era17).at(1);
-	  hadtrigger = mctriggers.at(Era17).at(2);
-	}
-	else if (Year==2018){
-	  eltrigger = mctriggers.at("18").at(0);
-	  mutrigger =  mctriggers.at("18").at(1);
-	  hadtrigger = mctriggers.at("18").at(2);
-	}
-      }
-      
-      if(isMC){
-	for(unsigned int itrig=0; itrig < vsSelMCTriggersHad_MultiLepCalc->size(); itrig++){
-	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find(hadtrigger) != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) MCHadPastTrigger = 1;
-	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2") != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2 = 1;
-	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2") != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2 = 1;
-	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94") != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94 = 1;
-	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT400_SixJet30_DoubleBTagCSV_p056") != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT400_SixJet30_DoubleBTagCSV_p056 = 1;	
-	}
-	if(isElectron){
-	  for(unsigned int itrig=0; itrig < vsSelMCTriggersEl_MultiLepCalc->size(); itrig++){
-	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(eltrigger) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCLepPastTrigger = 1;
-	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele15_IsoVVVL_PFHT450") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele15_IsoVVVL_PFHT450 = 1;
-	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele28_eta2p1_WPTight_Gsf_HT150") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele28_eta2p1_WPTight_Gsf_HT150 = 1;
-	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned = 1;
-	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele32_WPTight_Gsf") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele32_WPTight_Gsf = 1;
-	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele35_WPTight_Gsf") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele35_WPTight_Gsf = 1;
-	    for(unsigned int jtrig=0; jtrig < eltriggersX.size(); jtrig++){
-	      if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(eltriggersX.at(jtrig)) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCPastTriggerX = 1;
-	    }
-	  }
-          EGammaGsfSF = hardcodedConditions.GetEGammaGsfSF(leppt, lepeta, Year);
-          lepIdSF = hardcodedConditions.GetElectronIdSF(leppt, lepeta, Year);
-          isoSF = hardcodedConditions.GetElectronIsoSF(leppt, lepeta, Year);
-          triggerSF = hardcodedConditions.GetElectronTriggerSF(leppt, AK4HT, Year);
-          triggerXSF = hardcodedConditions.GetElectronTriggerXSF(leppt, lepeta, Year);
-	}
-	if(isMuon){
-	  for(unsigned int itrig=0; itrig < vsSelMCTriggersMu_MultiLepCalc->size(); itrig++){
-	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(mutrigger) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCLepPastTrigger = 1;
- 	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu24") != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu24 = 1;
-	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu24_eta2p1") != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu24_eta2p1 = 1;
-	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu27") != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu27 = 1;
-	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find("HLT_Mu15_IsoVVVL_PFHT450") != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_Mu15_IsoVVVL_PFHT450 = 1;
-	    for(unsigned int jtrig=0; jtrig < mutriggersX.size(); jtrig++){
-	    	if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(mutriggersX.at(jtrig)) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCPastTriggerX = 1;
-	    }
-	  }
-	  lepIdSF = hardcodedConditions.GetMuonIdSF(leppt, lepeta, Year);
-	  isoSF = hardcodedConditions.GetMuonIsoSF(leppt, lepeta, Year);	  
-	  triggerSF = hardcodedConditions.GetMuonTriggerSF(leppt, AK4HT, Year); 
-	  triggerXSF = hardcodedConditions.GetMuonTriggerXSF(leppt, lepeta, Year); 
-	}
-	if (MCLepPastTrigger == 1 || MCHadPastTrigger == 1){
-	  MCPastTrigger = 1;
-	}
-
-	DataPastTrigger = 1;
-	DataPastTriggerX = 1;
-	DataLepPastTrigger = 1;
-	DataHadPastTrigger = 1;
-      }
-      else{ //Data triggers check
-	for(unsigned int itrig=0; itrig < vsSelTriggersHad_MultiLepCalc->size(); itrig++){
-	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find(hadtrigger) != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) DataHadPastTrigger = 1;
-	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixJet32_DoubleBTagCSV_p075") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixJet32_DoubleBTagCSV_p075 = 1;
-	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2 = 1;
-	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2 = 1;
-	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94 = 1;
-	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT400_SixJet30_DoubleBTagCSV_p056") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT400_SixJet30_DoubleBTagCSV_p056 = 1;	
-	}
-	if(isElectron){
-	  //if(isSE){
-	  for(unsigned int itrig=0; itrig < vsSelTriggersEl_MultiLepCalc->size(); itrig++){
-	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(eltrigger) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataLepPastTrigger = 1;
-	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele15_IsoVVVL_PFHT450") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele15_IsoVVVL_PFHT450 = 1;
-	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele28_eta2p1_WPTight_Gsf_HT150") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele28_eta2p1_WPTight_Gsf_HT150 = 1;
-	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned = 1;
-	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele32_WPTight_Gsf") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele32_WPTight_Gsf = 1;
-	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele35_WPTight_Gsf") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele35_WPTight_Gsf = 1;
-	    for(unsigned int jtrig=0; jtrig < eltriggersX.size(); jtrig++){
-	      if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(eltriggersX.at(jtrig)) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataPastTriggerX = 1;
-	    }
-	  }
-	  //else if(isHad){
-	  if (DataLepPastTrigger == 1 || DataHadPastTrigger == 1){
-	    DataPastTrigger = 1; 
-	  }
-	    //}
-	}
-	if(isMuon){
-	  //if(isSM){
-	  for(unsigned int itrig=0; itrig < vsSelTriggersMu_MultiLepCalc->size(); itrig++){
-	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(mutrigger) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataLepPastTrigger = 1;
- 	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu24") != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu24 = 1;
-	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu24_eta2p1") != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu24_eta2p1 = 1;
-	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu27") != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu27 = 1;
-	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find("HLT_Mu15_IsoVVVL_PFHT450") != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_Mu15_IsoVVVL_PFHT450 = 1;
-	    for(unsigned int jtrig=0; jtrig < mutriggersX.size(); jtrig++){
-	      if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(mutriggersX.at(jtrig)) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataPastTriggerX = 1;
-	    }
-	  }
-	  if (DataLepPastTrigger == 1 || DataHadPastTrigger == 1){
-	    DataPastTrigger = 1;
-	  }
-	  //}
-	}
-	MCPastTrigger = 1;
-	MCPastTriggerX = 1;
-	MCLepPastTrigger = 1;
-	MCHadPastTrigger = 1;
-      }
-      
-      if(isMC && MCPastTrigger) npass_trigger+=1;
-      if(!isMC && DataPastTrigger) npass_trigger+=1;
-
-      // ----------------------------------------------------------------------------
       // Generator-level HT correction
       // ----------------------------------------------------------------------------      
 
@@ -1102,6 +908,212 @@ void step1::Loop(TString inTreeName, TString outTreeName )
 	NJets_JetSubCalc+=1;
 	AK4HT+=theJetPt_JetSubCalc->at(ijet);
       }
+
+
+
+       // ----------------------------------------------------------------------------
+      // Assign Lepton scale factor or efficiency weights, save trigger pass/fail
+      // ----------------------------------------------------------------------------
+
+      // Triggers Initialised to ZERO
+      HLT_Ele15_IsoVVVL_PFHT450 = 0;
+      HLT_Ele28_eta2p1_WPTight_Gsf_HT150 = 0;
+      HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned = 0;
+      HLT_Mu15_IsoVVVL_PFHT450 = 0;
+      HLT_PFHT400_SixJet30_DoubleBTagCSV_p056 = 0;
+      HLT_Ele32_WPTight_Gsf = 0;
+      HLT_Ele35_WPTight_Gsf = 0;
+      HLT_IsoMu24 = 0;
+      HLT_IsoMu24_eta2p1 = 0;
+      HLT_IsoMu27 = 0;
+      HLT_PFHT380_SixJet32_DoubleBTagCSV_p075 = 0; // only data for 17B
+      HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2 = 0; // only MC for 17B
+      HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2 = 0;
+      HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94 = 0; // in 2018
+
+      DataPastTriggerX = 0;
+      MCPastTriggerX = 0;
+      DataPastTrigger = 0;
+      MCPastTrigger = 0;
+      DataLepPastTrigger = 0;
+      MCLepPastTrigger = 0;
+      DataHadPastTrigger = 0;
+      MCHadPastTrigger = 0;
+      EGammaGsfSF = 1.0;
+      lepIdSF = 1.0;
+      triggerSF = 1.0;
+      triggerHadSF = 1.0;
+      triggerXSF = 1.0;
+      isoSF = 1.0;
+      std::vector<std::string> eltriggersX;
+      std::vector<std::string> mutriggersX;
+      if(Year==2017){
+      eltriggersX = {"Ele15_IsoVVVL_PFHT450","Ele50_IsoVVVL_PFHT450","Ele15_IsoVVVL_PFHT600","Ele35_WPTight_Gsf","Ele38_WPTight_Gsf"};
+      mutriggersX = {"Mu15_IsoVVVL_PFHT450","Mu50_IsoVVVL_PFHT450","Mu15_IsoVVVL_PFHT600","Mu50"};
+      }
+      else if(Year==2018){
+      eltriggersX = {"Ele15_IsoVVVL_PFHT450","Ele50_IsoVVVL_PFHT450","Ele15_IsoVVVL_PFHT600","Ele35_WPTight_Gsf","Ele38_WPTight_Gsf","Ele15_IsoVVVL_PFHT450_PFMET50"};
+      mutriggersX = {"Mu15_IsoVVVL_PFHT450","Mu50_IsoVVVL_PFHT450","Mu15_IsoVVVL_PFHT600","Mu50","TkMu50","Mu15_IsoVVVL_PFHT450_PFMET50"};
+      }
+      std::string eltrigger;
+      std::string mutrigger;
+      std::string hadtrigger;
+      std::vector<std::string> eltriggers;
+      std::vector<std::string> mutriggers;
+      std::vector<std::string> hadtriggers;
+      std::map<TString, std::vector<std::string>> mctriggers;
+      mctriggers = {{"17B", {"Ele35_WPTight_Gsf", "IsoMu24_eta2p1" , "PFHT380_SixPFJet32_DoublePFBTagCSV_2p2" }},
+		    {"17C",{"Ele35_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagCSV_2p2" }},
+		    {"17DEF",{"Ele32_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
+		    {"18",{"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94" }}};
+
+
+      std::map<TString, std::vector<std::string>> datatriggers;
+      datatriggers = {{"17B", {"Ele35_WPTight_Gsf", "IsoMu24_eta2p1" , "PFHT380_SixJet32_DoubleBTagCSV_p075" }},
+		      {"17C",{"Ele35_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagCSV_2p2" }},
+		      {"17DEF",{"Ele32_WPTight_Gsf", "IsoMu27" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
+		      {"18AB", {"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2" }},
+		      {"18CD",{"Ele32_WPTight_Gsf", "IsoMu24" , "PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94" }}};
+      if (!isMC){
+	eltrigger = datatriggers.at(Era).at(0);
+	mutrigger =  datatriggers.at(Era).at(1);
+	hadtrigger = datatriggers.at(Era).at(2);
+      }
+      else{
+	if (Year==2017){
+	  TRandom3 r;
+	  //TRandom3 *r = new TRandom3();
+	  float randLumi = r.Uniform(1.);
+	  //Double_t randLumi = r->Rndm();
+	  TString Era17;
+	  float eraBupperLumi = (4.823/41.557);
+	  float eraCupperLumi = (14.487/41.557);
+	  if(randLumi>=0 && randLumi<= eraBupperLumi) Era17="17B";
+	  else if(randLumi>eraBupperLumi && randLumi<=eraCupperLumi) Era17="17C";
+	  else Era17="17DEF";
+	  eltrigger = mctriggers.at(Era17).at(0);
+	  mutrigger =  mctriggers.at(Era17).at(1);
+	  hadtrigger = mctriggers.at(Era17).at(2);
+	}
+	else if (Year==2018){
+	  eltrigger = mctriggers.at("18").at(0);
+	  mutrigger =  mctriggers.at("18").at(1);
+	  hadtrigger = mctriggers.at("18").at(2);
+	}
+      }
+
+      if(isMC){
+	for(unsigned int itrig=0; itrig < vsSelMCTriggersHad_MultiLepCalc->size(); itrig++){
+	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find(hadtrigger) != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) MCHadPastTrigger = 1;
+	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2") != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2 = 1;
+	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2") != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2 = 1;
+	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94") != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94 = 1;
+	  if(vsSelMCTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT400_SixJet30_DoubleBTagCSV_p056") != std::string::npos && viSelMCTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT400_SixJet30_DoubleBTagCSV_p056 = 1;
+	}
+	if(isElectron){
+	  for(unsigned int itrig=0; itrig < vsSelMCTriggersEl_MultiLepCalc->size(); itrig++){
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(eltrigger) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCLepPastTrigger = 1;
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele15_IsoVVVL_PFHT450") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele15_IsoVVVL_PFHT450 = 1;
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele28_eta2p1_WPTight_Gsf_HT150") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele28_eta2p1_WPTight_Gsf_HT150 = 1;
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned = 1;
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele32_WPTight_Gsf") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele32_WPTight_Gsf = 1;
+	    if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele35_WPTight_Gsf") != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele35_WPTight_Gsf = 1;
+	    for(unsigned int jtrig=0; jtrig < eltriggersX.size(); jtrig++){
+	      if(vsSelMCTriggersEl_MultiLepCalc->at(itrig).find(eltriggersX.at(jtrig)) != std::string::npos && viSelMCTriggersEl_MultiLepCalc->at(itrig) > 0) MCPastTriggerX = 1;
+	    }
+	  }
+          EGammaGsfSF = hardcodedConditions.GetEGammaGsfSF(leppt, lepeta, Year);
+          lepIdSF = hardcodedConditions.GetElectronIdSF(leppt, lepeta, Year);
+          isoSF = hardcodedConditions.GetElectronIsoSF(leppt, lepeta, Year);
+          triggerSF = hardcodedConditions.GetElectronTriggerSF(leppt, lepeta, Year);
+          triggerHadSF = hardcodedConditions.GetIsEHadronTriggerSF(NJets_JetSubCalc, AK4HT, Year);
+          triggerXSF = hardcodedConditions.GetElectronTriggerXSF(leppt, lepeta, Year);
+	}
+	if(isMuon){
+	  for(unsigned int itrig=0; itrig < vsSelMCTriggersMu_MultiLepCalc->size(); itrig++){
+	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(mutrigger) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCLepPastTrigger = 1;
+ 	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu24") != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu24 = 1;
+	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu24_eta2p1") != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu24_eta2p1 = 1;
+	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu27") != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu27 = 1;
+	    if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find("HLT_Mu15_IsoVVVL_PFHT450") != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_Mu15_IsoVVVL_PFHT450 = 1;
+	    for(unsigned int jtrig=0; jtrig < mutriggersX.size(); jtrig++){
+	    	if(vsSelMCTriggersMu_MultiLepCalc->at(itrig).find(mutriggersX.at(jtrig)) != std::string::npos && viSelMCTriggersMu_MultiLepCalc->at(itrig) > 0) MCPastTriggerX = 1;
+	    }
+	  }
+	  lepIdSF = hardcodedConditions.GetMuonIdSF(leppt, lepeta, Year);
+	  isoSF = hardcodedConditions.GetMuonIsoSF(leppt, lepeta, Year);
+	  triggerSF = hardcodedConditions.GetMuonTriggerSF(leppt, lepeta, Year);
+	  triggerHadSF = hardcodedConditions.GetIsMHadronTriggerSF(NJets_JetSubCalc, AK4HT, Year);
+	  triggerXSF = hardcodedConditions.GetMuonTriggerXSF(leppt, lepeta, Year);
+	}
+	if (MCLepPastTrigger == 1 || MCHadPastTrigger == 1){
+	  MCPastTrigger = 1;
+	}
+
+	DataPastTrigger = 1;
+	DataPastTriggerX = 1;
+	DataLepPastTrigger = 1;
+	DataHadPastTrigger = 1;
+      }
+      else{ //Data triggers check
+	for(unsigned int itrig=0; itrig < vsSelTriggersHad_MultiLepCalc->size(); itrig++){
+	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find(hadtrigger) != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) DataHadPastTrigger = 1;
+	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixJet32_DoubleBTagCSV_p075") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixJet32_DoubleBTagCSV_p075 = 1;
+	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixPFJet32_DoublePFBTagDeepCSV_2p2 = 1;
+	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT380_SixPFJet32_DoublePFBTagCSV_2p2 = 1;
+	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT400_SixPFJet32_DoublePFBTagDeepCSV_2p94 = 1;
+	  if(vsSelTriggersHad_MultiLepCalc->at(itrig).find("HLT_PFHT400_SixJet30_DoubleBTagCSV_p056") != std::string::npos && viSelTriggersHad_MultiLepCalc->at(itrig) > 0) HLT_PFHT400_SixJet30_DoubleBTagCSV_p056 = 1;
+	}
+	if(isElectron){
+	  //if(isSE){
+	  for(unsigned int itrig=0; itrig < vsSelTriggersEl_MultiLepCalc->size(); itrig++){
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(eltrigger) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataLepPastTrigger = 1;
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele15_IsoVVVL_PFHT450") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele15_IsoVVVL_PFHT450 = 1;
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele28_eta2p1_WPTight_Gsf_HT150") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele28_eta2p1_WPTight_Gsf_HT150 = 1;
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele30_eta2p1_WPTight_Gsf_CentralPFJet35_EleCleaned = 1;
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele32_WPTight_Gsf") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele32_WPTight_Gsf = 1;
+	    if(vsSelTriggersEl_MultiLepCalc->at(itrig).find("HLT_Ele35_WPTight_Gsf") != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) HLT_Ele35_WPTight_Gsf = 1;
+	    for(unsigned int jtrig=0; jtrig < eltriggersX.size(); jtrig++){
+	      if(vsSelTriggersEl_MultiLepCalc->at(itrig).find(eltriggersX.at(jtrig)) != std::string::npos && viSelTriggersEl_MultiLepCalc->at(itrig) > 0) DataPastTriggerX = 1;
+	    }
+	  }
+	  //else if(isHad){
+	  if (DataLepPastTrigger == 1 || DataHadPastTrigger == 1){
+	    DataPastTrigger = 1;
+	  }
+	    //}
+	}
+	if(isMuon){
+	  //if(isSM){
+	  for(unsigned int itrig=0; itrig < vsSelTriggersMu_MultiLepCalc->size(); itrig++){
+	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(mutrigger) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataLepPastTrigger = 1;
+ 	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu24") != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu24 = 1;
+	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu24_eta2p1") != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu24_eta2p1 = 1;
+	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find("HLT_IsoMu27") != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_IsoMu27 = 1;
+	    if(vsSelTriggersMu_MultiLepCalc->at(itrig).find("HLT_Mu15_IsoVVVL_PFHT450") != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) HLT_Mu15_IsoVVVL_PFHT450 = 1;
+	    for(unsigned int jtrig=0; jtrig < mutriggersX.size(); jtrig++){
+	      if(vsSelTriggersMu_MultiLepCalc->at(itrig).find(mutriggersX.at(jtrig)) != std::string::npos && viSelTriggersMu_MultiLepCalc->at(itrig) > 0) DataPastTriggerX = 1;
+	    }
+	  }
+	  if (DataLepPastTrigger == 1 || DataHadPastTrigger == 1){
+	    DataPastTrigger = 1;
+	  }
+	  //}
+	}
+	MCPastTrigger = 1;
+	MCPastTriggerX = 1;
+	MCLepPastTrigger = 1;
+	MCHadPastTrigger = 1;
+      }
+
+      if(isMC && MCPastTrigger) npass_trigger+=1;
+      if(!isMC && DataPastTrigger) npass_trigger+=1;
+
+
+
+
+
+
 
 
       // ----------------------------------------------------------------------------

--- a/step1/step1.h
+++ b/step1/step1.h
@@ -114,6 +114,7 @@ public :
    Float_t         MuTrkSF;
    Float_t         EGammaGsfSF;
    Float_t         triggerSF;
+   Float_t         triggerHadSF;
    Float_t         triggerXSF;
    Float_t         JetSF_80X;
    Float_t         JetSFup_80X;

--- a/step1/step1.h
+++ b/step1/step1.h
@@ -201,12 +201,15 @@ public :
    Float_t         minMleppJet;
    Float_t         deltaR_lepMinMlj;
    Float_t         minDR_lepJet;
+   Float_t         minDR_jetJet;
    Float_t         ptRel_lepJet;
    Float_t         ptRel_lepAK8;
    Float_t         minDPhi_MetJet;
    Float_t         MT_lepMet;
    Float_t         MT_lepMetmod;
+   double          deltaR_jetJets;
    vector<double>  deltaR_lepJets;
+   vector<double>  minDR_jetJets;
    vector<double>  deltaPhi_lepJets;
    vector<double>  mass_lepJets;
 

--- a/step1/submitQsubSlimmerJobs.sh
+++ b/step1/submitQsubSlimmerJobs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+date
+
+echo "SUBMITTING nominal"
+
+python -u runQsubSlimmerJobs.py nominal
+
+sleep 5
+
+echo "SUBMITTING JECup"
+
+python -u runQsubSlimmerJobs.py JECup
+
+sleep 5
+
+echo "SUBMITTING JECdown"
+
+python -u runQsubSlimmerJobs.py JECdown
+
+sleep 5
+
+echo "SUBMITTING JERup"
+
+python -u runQsubSlimmerJobs.py JERup
+
+sleep 5
+
+echo "SUBMITTING JERdown"
+
+python -u runQsubSlimmerJobs.py JERdown
+
+sleep 5
+
+echo "DONE"
+
+date
+

--- a/step1/submitQsubSlimmerJobs.sh
+++ b/step1/submitQsubSlimmerJobs.sh
@@ -6,31 +6,31 @@ echo "SUBMITTING nominal"
 
 python -u runQsubSlimmerJobs.py nominal
 
-sleep 5
-
-echo "SUBMITTING JECup"
-
-python -u runQsubSlimmerJobs.py JECup
-
-sleep 5
-
-echo "SUBMITTING JECdown"
-
-python -u runQsubSlimmerJobs.py JECdown
-
-sleep 5
-
-echo "SUBMITTING JERup"
-
-python -u runQsubSlimmerJobs.py JERup
-
-sleep 5
-
-echo "SUBMITTING JERdown"
-
-python -u runQsubSlimmerJobs.py JERdown
-
-sleep 5
+#sleep 5
+#
+#echo "SUBMITTING JECup"
+#
+#python -u runQsubSlimmerJobs.py JECup
+#
+#sleep 5
+#
+#echo "SUBMITTING JECdown"
+#
+#python -u runQsubSlimmerJobs.py JECdown
+#
+#sleep 5
+#
+#echo "SUBMITTING JERup"
+#
+#python -u runQsubSlimmerJobs.py JERup
+#
+#sleep 5
+#
+#echo "SUBMITTING JERdown"
+#
+#python -u runQsubSlimmerJobs.py JERdown
+#
+#sleep 5
 
 echo "DONE"
 


### PR DESCRIPTION
I added the xSFs produced by me in the HardcoddedConditions. For 2017 this is split in 17B and 17CDEF. 

I wonder wether it is better to have an all inclussive SF for 2017 instead of using the luminosity fractions for 17B and 17CDEF. Also, for the cases of SF in 17B being 0 at low some low pt bins; then maybe just take SF_17CDEF only.