### PR TITLE
fixes

### DIFF
--- a/step1/makeStep1.sh
+++ b/step1/makeStep1.sh
@@ -56,11 +56,14 @@ for SHIFT in nominal JECup JECdown JERup JERdown
   do
   haddFile=${outfilename}_${ID}${SHIFT}_hadd.root
   hadd ${haddFile} *${SHIFT}.root
-  # echo "xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/}"
-  #xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/} 2>&1
-
-  echo "gfal-copy -f file://$TMPDIR/${haddFile} srm://maite.iihe.ac.be:8443/pnfs/iihe/cms/store/user/$USER/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/}"
-  gfal-copy -f file://$TMPDIR/${haddFile} srm://maite.iihe.ac.be:8443/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/} 2>&1
+  if [[ $outputDir == /pnfs/iihe/* ]] ;
+  then # for qsub jobs
+    echo "gfal-copy -f file://$TMPDIR/${haddFile} srm://maite.iihe.ac.be:8443/pnfs/iihe/cms/store/user/$USER/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/}"
+    gfal-copy -f file://$TMPDIR/${haddFile} srm://maite.iihe.ac.be:8443/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/} 2>&1
+  else # for condor jobs on lpc
+    echo "xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/}"
+    xrdcp -f ${haddFile} root://cmseos.fnal.gov/${outputDir//$NOM/$SHIFT}/${haddFile//${SHIFT}_hadd/} 2>&1
+  fi
 
   XRDEXIT=$?
   if [[ $XRDEXIT -ne 0 ]]; then

--- a/step1/runCondorSlimmerJobs.py
+++ b/step1/runCondorSlimmerJobs.py
@@ -9,13 +9,14 @@ start_time = time.time()
 
 #IO directories must be full paths
 
-Year = 2017 # or 2018
+Year = 2018 # or 2018
 finalStateYear = 'singleLep'+str(Year)
 inputDir='/eos/uscms/store/user/lpcljm/FWLJMET102X_1lep'+str(Year)+'_Oct2019/' # or 2018
 #inputDir='/isilon/hadoop/store/group/bruxljm/FWLJMET102X_1lep'+str(Year)+'_Oct2019/' # or 2018
-outputDir='/eos/uscms/store/user/ssagir/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_041220_step1/nominal/' # or 2018
-condorDir='/uscms_data/d3/ssagir/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_041220_step1/' # or 2018
+outputDir='/eos/uscms/store/user/ssagir/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_071420_step1/nominal/' # or 2018
+condorDir='/uscms_data/d3/ssagir/FWLJMET102X_1lep'+str(Year)+'_Oct2019_4t_071420_step1/' # or 2018
 shifts = ['JECup','JECdown','JERup','JERdown']
+nFilesPerJob=30
 inputLoc='lpc'
 if inputDir.startswith('/isilon/hadoop/'): inputLoc='brux'
 
@@ -230,7 +231,6 @@ for sample in dirList:
                 basefilename = '_'.join(basefilename)
                 print "Running path:",pathsuffix,"\tBase filenames:",basefilename
 
-                nFilesPerJob=30
                 for i in range(0,len(rootfiles),nFilesPerJob):
                     count+=1
                     tmpcount += 1
@@ -259,6 +259,11 @@ for sample in dirList:
                             idlist += (rootfiles[j].split('.')[0]).split('_')[-1]+' '
                         
                     idlist = idlist.strip()
+                    #remove the problematic 2018 fwljmet jobs
+                    if Year==2018 and sample=='ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8':
+                    	problematicIDs = ['1048','1177','1217','1412','1413','1414','1415','1416','1417','1418','1419','1429','1441','1664','1883']
+                    	for id_ in problematicIDs:
+                    		idlist = idlist.replace(id_,'').replace('  ',' ')
                     print "Running IDs",idlist
                 
                     dict={'RUNDIR':runDir, 'SAMPLE':sample, 'INPATHSUFFIX':pathsuffix, 'INPUTDIR':inDir, 'FILENAME':basefilename, 'OUTFILENAME':outsample, 'OUTPUTDIR':outDir, 'LIST':idlist, 'ID':tmpcount, 'YEAR':Year}

--- a/step1/step1.cc
+++ b/step1/step1.cc
@@ -1450,7 +1450,16 @@ void step1::Loop(TString inTreeName, TString outTreeName )
       // ----------------------------------------------------------------------------
       // Skip events that fail # of btag requirement
       // ----------------------------------------------------------------------------  
-      if(NJetsCSVwithSF_MultiLepCalc<nbjetsCut && NJetsCSVwithSF_MultiLepCalc_bSFup<nbjetsCut && NJetsCSVwithSF_MultiLepCalc_bSFdn<nbjetsCut && NJetsCSVwithSF_MultiLepCalc_lSFup<nbjetsCut && NJetsCSVwithSF_MultiLepCalc_lSFdn<nbjetsCut) continue;
+      if(NJetsCSVwithSF_MultiLepCalc<nbjetsCut && 
+      	 NJetsCSVwithSF_MultiLepCalc_bSFup<nbjetsCut && 
+      	 NJetsCSVwithSF_MultiLepCalc_bSFdn<nbjetsCut && 
+      	 NJetsCSVwithSF_MultiLepCalc_lSFup<nbjetsCut && 
+      	 NJetsCSVwithSF_MultiLepCalc_lSFdn<nbjetsCut && 
+      	 NJetsCSVwithSF_JetSubCalc<nbjetsCut && 
+      	 NJetsCSVwithSF_JetSubCalc_bSFup<nbjetsCut && 
+      	 NJetsCSVwithSF_JetSubCalc_bSFdn<nbjetsCut && 
+      	 NJetsCSVwithSF_JetSubCalc_lSFup<nbjetsCut && 
+      	 NJetsCSVwithSF_JetSubCalc_lSFdn<nbjetsCut) continue;
 
       // ----------------------------------------------------------------------------
       // 13TeV Top pT reweighting -- TTbarMassCalc top vectors are the wrong tops....


### PR DESCRIPTION
1. Use xrdcp for lpc condor jobs in makeStep1.sh (instead of gfal-copy introduced by Nikos for Qsub)
2. Remove problematic Single top sample input files (only for 2018 samples). There are some corrupted FWLJMET jobs in this sample and causing problems in step1 jobs.
3. Apply the # b-tag selection so that both Deep CSV and Deep Jet algorithms can be used (Previously the selection is applied only using Deep CSV). 
